### PR TITLE
Add UI, PostgreSQL, Minio and S3 relations

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,6 +30,47 @@ requires:
     interface: postgresql_client
     limit: 1
 
+  object-storage:
+    interface: object-storage
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            access-key:
+              type: string
+            namespace:
+              type:
+              - string
+              - 'null'
+            port:
+              type: number
+            secret-key:
+              type: string
+            secure:
+              type: boolean
+            service:
+              type: string
+          required:
+          - access-key
+          - port
+          - secret-key
+          - secure
+          - service
+    versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+
+  s3-parameters:
+    interface: s3
+    limit: 1
+    optional: true
+
+provides:
+  airbyte-server:
+    interface: airbyte-server
+    optional: true
+    limit: 1
+
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
 # tab on Charmhub.
@@ -55,28 +96,34 @@ config:
       description: |
         Storage type for logs.
 
-        Acceptable values are: "minio"
-      default: "minio"
+        Acceptable values are: "MINIO", "S3" (AWS)
+      default: "MINIO"
       type: string
 
-    storage-bucket-log:
-      description: Temporal server host.
+    storage-bucket-logs:
+      description: Name of logs storage bucket.
       default: "airbyte-dev-logs"
       type: string
 
+    logs-ttl:
+      description: |
+        Number of days until logs are purged from object storage.
+      default: 30
+      type: int
+
     storage-bucket-state:
-      description: Name of state storage bucker.
-      default: "state-storage"
+      description: Name of state storage bucket.
+      default: "airbyte-state-storage"
       type: string
 
     storage-bucket-activity-payload:
       description: Name of activity payload storage bucket.
-      default: "payload-storage"
+      default: "airbyte-payload-storage"
       type: string
 
     storage-bucket-workload-output:
       description: Name of workload output storage bucket.
-      default: "state-storage"
+      default: "airbyte-state-storage"
       type: string
 
     pod-running-ttl-minutes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 ops ~= 2.5
 pydantic==1.10.12
+boto3==1.34.31
+serialized-data-interface==0.7.0
+charmed-kubeflow-chisme==0.3.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,36 +8,30 @@ import logging
 from pathlib import Path
 
 import ops
+from botocore.exceptions import ClientError
+from charm_helpers import create_env
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
+from charms.data_platform_libs.v0.database_requires import DatabaseRequires
+from charms.data_platform_libs.v0.s3 import S3Requirer
+from literals import (
+    BUCKET_CONFIGS,
+    CONNECTOR_BUILDER_SERVER_API_PORT,
+    CONTAINERS,
+    INTERNAL_API_PORT,
+    LOGS_BUCKET_CONFIG,
+    REQUIRED_S3_PARAMETERS,
+)
 from log import log_event_handler
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from relations.airbyte_ui import AirbyteServer
+from relations.minio import MinioRelation
+from relations.postgresql import PostgresqlRelation
+from relations.s3 import S3Integrator
+from s3_helpers import S3Client
 from state import State
-from structured_config import CharmConfig
+from structured_config import CharmConfig, StorageType
 
 logger = logging.getLogger(__name__)
-
-CONTAINERS = [
-    "airbyte-api-server",
-    "airbyte-bootloader",
-    "airbyte-connector-builder-server",
-    "airbyte-cron",
-    "airbyte-pod-sweeper",
-    "airbyte-server",
-    "airbyte-worker",
-]
-CONNECTOR_BUILDER_SERVER_API_PORT = 80
-INTERNAL_API_PORT = 8001
-AIRBYTE_API_PORT = 8006
-WORKLOAD_API_PORT = 8007
-
-# TODO (kelkawi-a): perform up check on the following ports for each container
-# airbyte-api-server: 8006
-# airbyte-bootloader: None
-# airbyte-connector-builder-server: 8080
-# airbyte-cron: 9001
-# airbyte-pod-sweeper: None
-# airbyte-server: 8001
-# airbyte-worker: 9000
 
 
 def get_pebble_layer(application_name, context):
@@ -67,13 +61,38 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         self._state = State(self.app, lambda: self.model.get_relation("peer"))
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.peer_relation_changed, self._on_peer_relation_changed)
 
-        for container in CONTAINERS:
+        # Handle postgresql relation.
+        self.db = DatabaseRequires(
+            self, relation_name="db", database_name="airbyte-k8s_db", extra_user_roles="admin"
+        )
+        self.postgresql = PostgresqlRelation(self)
+
+        self.minio = MinioRelation(self)
+
+        # Handle S3 integrator relation
+        self.s3_client = S3Requirer(self, "s3-parameters")
+        self.s3_relation = S3Integrator(self)
+
+        # Handle UI relation
+        self.airbyte_ui = AirbyteServer(self)
+
+        for container in list(CONTAINERS.keys()):
             self.framework.observe(self.on[container].pebble_ready, self._on_pebble_ready)
 
     @log_event_handler(logger)
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         """Handle pebble-ready event."""
+        self._update(event)
+
+    @log_event_handler(logger)
+    def _on_peer_relation_changed(self, event):
+        """Handle peer relation changed event.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
         self._update(event)
 
     @log_event_handler(logger)
@@ -86,88 +105,45 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         self.unit.status = WaitingStatus("configuring application")
         self._update(event)
 
-    # TODO (kelkawi-a): Potentially move this to helpers.py later on
-    def _create_env(self):
-        db_conn = self._state.database_connections["db"]
+    def _check_missing_params(self, params, required_params):
+        """Validate that all required properties were extracted.
 
-        host = db_conn["host"]
-        port = db_conn["port"]
-        db_name = db_conn["dbname"]
-        db_url = f"jdbc:postgresql://{host}:{port}/{db_name}"
+        Args:
+            params: dictionary of parameters extracted from relation.
+            required_params: list of required parameters.
 
-        # TODO (kelkawi-a): modify some of these values to grab data from relations instead
-        return {
-            "API_URL": "/api/v1/",
-            "AIRBYTE_VERSION": "0.57.3",
-            "AIRBYTE_EDITION": "community",
-            "AUTO_DETECT_SCHEMA": "true",
-            "DATABASE_URL": db_url,
-            "DATABASE_USER": db_conn["user"],
-            "DATABASE_PASSWORD": db_conn["password"],
-            "DATABASE_DB": db_name,
-            "DATABASE_HOST": host,
-            "DATABASE_PORT": port,
-            "WORKSPACE_ROOT": "/workspace",
-            "CONFIG_ROOT": "/configs",
-            "TEMPORAL_HOST": self.config["temporal-host"],
-            "WORKER_LOGS_STORAGE_TYPE": self.config["storage-type"].value,
-            "WORKER_STATE_STORAGE_TYPE": self.config["storage-type"].value,
-            "STORAGE_TYPE": self.config["storage-type"].value,
-            "STORAGE_BUCKET_ACTIVITY_PAYLOAD": "payload-storage",
-            "STORAGE_BUCKET_LOG": self.config["storage-bucket-log"],
-            "STORAGE_BUCKET_STATE": self.config["storage-bucket-state"],
-            "STORAGE_BUCKET_WORKLOAD_OUTPUT": self.config["storage-bucket-workload-output"],
-            "CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION": "0.40.23.002",
-            "JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION": "0.40.26.001",
-            "MICRONAUT_ENVIRONMENTS": "control-plane",
-            "WORKERS_MICRONAUT_ENVIRONMENTS": "control-plane",
-            "CRON_MICRONAUT_ENVIRONMENTS": "control-plane",
-            "INTERNAL_API_HOST": f"localhost:{INTERNAL_API_PORT}",
-            "LOG_LEVEL": self.config["log-level"].value,
-            "MICROMETER_METRICS_ENABLED": "false",
-            "KEYCLOAK_INTERNAL_HOST": "localhost",
-            "KEYCLOAK_DATABASE_URL": db_url + "?currentSchema=keycloak",
-            "WEBAPP_URL": "airbyte-ui-k8s:8080",
-            "WORKER_ENVIRONMENT": "kubernetes",
-            "WORKSPACE_DOCKER_MOUNT": "airbyte_workspace",
-            "SECRET_PERSISTENCE": "TESTING_CONFIG_DB_TABLE",
-            "CONNECTOR_BUILDER_SERVER_API_HOST": f"localhost:{CONNECTOR_BUILDER_SERVER_API_PORT}",
-            "S3_LOG_BUCKET_REGION": "",
-            "MINIO_ENDPOINT": "http://minio:9000",
-            "S3_LOG_BUCKET": "airbyte-dev-logs",
-            "S3_PATH_STYLE_ACCESS": "true",
-            "SHOULD_RUN_NOTIFY_WORKFLOWS": "true",
-            "STATE_STORAGE_MINIO_ACCESS_KEY": "minio",
-            "STATE_STORAGE_MINIO_SECRET_ACCESS_KEY": "minio123",
-            "STATE_STORAGE_MINIO_BUCKET_NAME": "state-storage",
-            "STATE_STORAGE_MINIO_ENDPOINT": "http://minio:9000",
-            "AIRBYTE_API_HOST": "localhost:8006",
-            "CONNECTOR_BUILDER_API_URL": "/connector-builder-api",
-            "WORKLOAD_API_HOST": "localhost:8007",
-            "WORKLOAD_API_URL": "localhost:8007",
-            "TEMPORAL_WORKER_PORTS": "9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030",
-            "AWS_ACCESS_KEY_ID": "minio",
-            "AWS_SECRET_ACCESS_KEY": "minio123",
-            "JOB_KUBE_SERVICEACCOUNT": "airbyte-k8s",
-            "JOB_KUBE_NAMESPACE": "dev-airbyte",
-            "RUNNING_TTL_MINUTES": self.config["pod-running-ttl-minutes"],
-            "SUCCEEDED_TTL_MINUTES": self.config["pod-successful-ttl-minutes"],
-            "UNSUCCESSFUL_TTL_MINUTES": self.config["pod-unsuccessful-ttl-minutes"],
-            "HTTP_PROXY": "http://squid.internal:3128",
-            "HTTPS_PROXY": "http://squid.internal:3128",
-            "NO_PROXY": "127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.canonical.com,.launchpad.net,.internal,.jujucharms.com,temporal-k8s,minio",
-            "http_proxy": "http://squid.internal:3128",
-            "https_proxy": "http://squid.internal:3128",
-            "no_proxy": "10.0.0.0/8,localhost,127.0.0.1,.internal,.cluster.local,.local,.svc,airbyte-*,temporal-k8s,minio",
-            "JAVA_TOOL_OPTIONS": "-Dhttp.proxyHost=squid.internal -Dhttp.proxyPort=3128 -Dhttps.proxyHost=squid.internal -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=10.0.0.0|localhost|127.0.0.1|*.internal|*.cluster.local|*.local|*.svc|airbyte-*|temporal-k8s|minio",
-            "JOB_DEFAULT_ENV_http_proxy": "http://squid.internal:3128",
-            "JOB_DEFAULT_ENV_https_proxy": "http://squid.internal:3128",
-            "JOB_DEFAULT_ENV_no_proxy": "127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.canonical.com,.launchpad.net,.internal,.jujucharms.com,temporal-k8s,minio",
-            "JOB_DEFAULT_ENV_HTTP_PROXY": "http://squid.internal:3128",
-            "JOB_DEFAULT_ENV_HTTPS_PROXY": "http://squid.internal:3128",
-            "JOB_DEFAULT_ENV_NO_PROXY": "127.0.0.1,localhost,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.canonical.com,.launchpad.net,.internal,.jujucharms.com,temporal-k8s,minio",
-            "JOB_DEFAULT_ENV_JAVA_TOOL_OPTIONS": "-Dhttp.proxyHost=squid.internal -Dhttp.proxyPort=3128 -Dhttps.proxyHost=squid.internal -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=10.0.0.0|localhost|127.0.0.1|*.internal|*.cluster.local|*.local|*.svc|airbyte-*|temporal-k8s|minio",
-        }
+        Returns:
+            list: List of OpenFGA parameters that are not set in state.
+        """
+        missing_params = []
+        for key in required_params:
+            if params.get(key) is None:
+                missing_params.append(key)
+        return missing_params
+
+    def _validate(self):
+        """Validate that configuration and relations are valid and ready.
+
+        Raises:
+            ValueError: in case of invalid configuration.
+        """
+        # Validate peer relation
+        if not self._state.is_ready():
+            raise ValueError("peer relation not ready")
+
+        # Validate db relation
+        if self._state.database_connection is None:
+            raise ValueError("database relation not ready")
+
+        # Validate db relation
+        if self._state.minio is None and self._state.s3 is None:
+            raise ValueError("minio/s3 relation not ready")
+
+        # Validate S3 relation.
+        if self._state.s3:
+            missing_params = self._check_missing_params(self._state.s3, REQUIRED_S3_PARAMETERS)
+            if len(missing_params) > 0:
+                raise ValueError(f"s3:missing parameters {missing_params!r}")
 
     def _update(self, event):
         """Update the Temporal server configuration and replan its execution.
@@ -175,16 +151,36 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         Args:
             event: The event triggered when the relation changed.
         """
-        # TODO (kelkawi-a): populate database connection from PostgreSQL relation
-        if not self._state.database_connections:
-            self.unit.status = BlockedStatus("missing db relation")
+        try:
+            self._validate()
+        except ValueError as err:
+            self.unit.status = BlockedStatus(str(err))
             return
 
-        env = self._create_env()
-        self.model.unit.set_ports(CONNECTOR_BUILDER_SERVER_API_PORT)
-        self.model.unit.set_ports(INTERNAL_API_PORT)
+        s3_parameters = self._state.s3
+        if self.config["storage-type"] == StorageType.minio:
+            s3_parameters = self._state.minio
 
-        for service in CONTAINERS:
+        try:
+            s3_client = S3Client(s3_parameters)
+
+            for bucket_config in BUCKET_CONFIGS:
+                bucket = self.config[bucket_config]
+                s3_client.create_bucket_if_not_exists(bucket)
+
+            logs_ttl = int(self.config["logs-ttl"])
+            s3_client.set_bucket_lifecycle_policy(
+                bucket=self.config[LOGS_BUCKET_CONFIG], ttl=logs_ttl
+            )
+        except (ClientError, ValueError) as e:
+            logging.info(f"Error creating bucket and setting lifecycle policy: {e}")
+            self.unit.status = BlockedStatus(f"failed to create buckets: {str(e)}")
+            return
+
+        env = create_env(self.model.name, self.app.name, self.config, self._state)
+        self.model.unit.set_ports(INTERNAL_API_PORT, CONNECTOR_BUILDER_SERVER_API_PORT)
+
+        for service in list(CONTAINERS.keys()):
             container = self.unit.get_container(service)
             if not container.can_connect():
                 event.defer()
@@ -196,7 +192,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 with open(script_path, "r") as file_source:
                     logger.info("pushing pod-sweeper script...")
                     container.push(
-                        "airbyte-app/bin/pod-sweeper.sh",
+                        f"/airbyte-app/bin/{service}",
                         file_source,
                         make_dirs=True,
                         permissions=0o755,
@@ -207,6 +203,8 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             container.replan()
 
         self.unit.status = ActiveStatus()
+        if self.unit.is_leader():
+            self.airbyte_ui._provide_server_status()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from literals import (
 )
 from log import log_event_handler
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-from relations.airbyte_ui import AirbyteServer
+from relations.airbyte_ui import AirbyteServerProvider
 from relations.minio import MinioRelation
 from relations.postgresql import PostgresqlRelation
 from relations.s3 import S3Integrator
@@ -76,7 +76,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         self.s3_relation = S3Integrator(self)
 
         # Handle UI relation
-        self.airbyte_ui = AirbyteServer(self)
+        self.airbyte_ui = AirbyteServerProvider(self)
 
         for container in list(CONTAINERS.keys()):
             self.framework.observe(self.on[container].pebble_ready, self._on_pebble_ready)
@@ -177,7 +177,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 bucket=self.config[LOGS_BUCKET_CONFIG], ttl=logs_ttl
             )
         except (ClientError, ValueError) as e:
-            logging.info(f"Error creating bucket and setting lifecycle policy: {e}")
+            logger.error(f"Error creating bucket and setting lifecycle policy: {e}")
             self.unit.status = BlockedStatus(f"failed to create buckets: {str(e)}")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,7 +113,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             required_params: list of required parameters.
 
         Returns:
-            list: List of OpenFGA parameters that are not set in state.
+            list: List of required parameters that are not set in state.
         """
         missing_params = []
         for key in required_params:
@@ -135,9 +135,13 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if self._state.database_connection is None:
             raise ValueError("database relation not ready")
 
-        # Validate db relation
-        if self._state.minio is None and self._state.s3 is None:
-            raise ValueError("minio/s3 relation not ready")
+        # Validate minio relation
+        if self.config["storage-type"] == StorageType.minio and self._state.minio is None:
+            raise ValueError("minio relation not ready")
+
+        # Validate S3 relation
+        if self.config["storage-type"] == StorageType.s3 and self._state.s3 is None:
+            raise ValueError("s3 relation not ready")
 
         # Validate S3 relation.
         if self._state.s3:

--- a/src/charm_helpers.py
+++ b/src/charm_helpers.py
@@ -1,0 +1,169 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm helpers."""
+
+import os
+from urllib.parse import urlparse
+
+from literals import (
+    AIRBYTE_API_PORT,
+    AIRBYTE_VERSION,
+    CONNECTOR_BUILDER_SERVER_API_PORT,
+    INTERNAL_API_PORT,
+    WORKLOAD_API_PORT,
+)
+from structured_config import StorageType
+
+
+def create_env(model_name, app_name, config, state):
+    db_conn = state.database_connection
+
+    host = db_conn["host"]
+    port = db_conn["port"]
+    db_name = db_conn["dbname"]
+    db_url = f"jdbc:postgresql://{host}:{port}/{db_name}"
+
+    if state.minio:
+        minio_endpoint = construct_svc_endpoint(
+            state.minio["service"],
+            state.minio["namespace"],
+            state.minio["port"],
+            state.minio["secure"],
+        )
+
+    minio_endpoint = "http://minio:9000"
+    env = {
+        "API_URL": "/api/v1/",
+        "AIRBYTE_VERSION": AIRBYTE_VERSION,
+        "AIRBYTE_EDITION": "community",
+        "AUTO_DETECT_SCHEMA": "true",
+        "DATABASE_URL": db_url,
+        "DATABASE_USER": db_conn["user"],
+        "DATABASE_PASSWORD": db_conn["password"],
+        "DATABASE_DB": db_name,
+        "DATABASE_HOST": host,
+        "DATABASE_PORT": port,
+        "WORKSPACE_ROOT": "/workspace",
+        "CONFIG_ROOT": "/configs",
+        "TEMPORAL_HOST": config["temporal-host"],
+        "WORKER_LOGS_STORAGE_TYPE": config["storage-type"].value,
+        "WORKER_STATE_STORAGE_TYPE": config["storage-type"].value,
+        "STORAGE_TYPE": config["storage-type"].value,
+        "STORAGE_BUCKET_LOG": config["storage-bucket-logs"],
+        "S3_LOG_BUCKET": config["storage-bucket-logs"],
+        "STORAGE_BUCKET_STATE": config["storage-bucket-state"],
+        "STORAGE_BUCKET_WORKLOAD_OUTPUT": config["storage-bucket-workload-output"],
+        "STORAGE_BUCKET_ACTIVITY_PAYLOAD": config["storage-bucket-activity-payload"],
+        "CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION": "0.40.23.002",
+        "JOBS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION": "0.40.26.001",
+        "MICRONAUT_ENVIRONMENTS": "control-plane",
+        "WORKERS_MICRONAUT_ENVIRONMENTS": "control-plane",
+        "CRON_MICRONAUT_ENVIRONMENTS": "control-plane",
+        "INTERNAL_API_HOST": f"localhost:{INTERNAL_API_PORT}",
+        "CONNECTOR_BUILDER_SERVER_API_HOST": f"localhost:{CONNECTOR_BUILDER_SERVER_API_PORT}",
+        "AIRBYTE_API_HOST": f"localhost:{AIRBYTE_API_PORT}",
+        "WORKLOAD_API_HOST": f"localhost:{WORKLOAD_API_PORT}",
+        "WORKLOAD_API_URL": f"localhost:{WORKLOAD_API_PORT}",
+        "LOG_LEVEL": config["log-level"].value,
+        "MICROMETER_METRICS_ENABLED": "false",
+        "LAUNCHER_MICRONAUT_ENVIRONMENTS": "control-plane,oss",
+        "KEYCLOAK_INTERNAL_HOST": "localhost",
+        "KEYCLOAK_DATABASE_URL": db_url + "?currentSchema=keycloak",
+        "WEBAPP_URL": "airbyte-ui-k8s:8080",
+        "WORKER_ENVIRONMENT": "kubernetes",
+        "SECRET_PERSISTENCE": "TESTING_CONFIG_DB_TABLE",
+        "SHOULD_RUN_NOTIFY_WORKFLOWS": "true",
+        "CONNECTOR_BUILDER_API_URL": "/connector-builder-api",
+        "TEMPORAL_WORKER_PORTS": "9001,9002,9003,9004,9005,9006,9007,9008,9009,9010,9011,9012,9013,9014,9015,9016,9017,9018,9019,9020,9021,9022,9023,9024,9025,9026,9027,9028,9029,9030",
+        "JOB_KUBE_SERVICEACCOUNT": app_name,
+        "JOB_KUBE_NAMESPACE": model_name,
+        "RUNNING_TTL_MINUTES": config["pod-running-ttl-minutes"],
+        "SUCCEEDED_TTL_MINUTES": config["pod-successful-ttl-minutes"],
+        "UNSUCCESSFUL_TTL_MINUTES": config["pod-unsuccessful-ttl-minutes"],
+    }
+
+    if config["storage-type"].value == StorageType.minio and state.minio:
+        env.update(
+            {
+                "MINIO_ENDPOINT": minio_endpoint,
+                "AWS_ACCESS_KEY_ID": state.minio["access-key"],
+                "AWS_SECRET_ACCESS_KEY": state.minio["secret-key"],
+                "S3_PATH_STYLE_ACCESS": "true",
+            }
+        )
+
+    if config["storage-type"].value == StorageType.s3 and state.s3:
+        env.update(
+            {
+                "AWS_ACCESS_KEY_ID": state.s3["access-key"],
+                "AWS_SECRET_ACCESS_KEY": state.s3["secret-key"],
+                "S3_LOG_BUCKET_REGION": state.s3["region"],
+                "AWS_DEFAULT_REGION": state.s3["region"],
+            }
+        )
+
+    http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+    https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+    no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+    java_tool_options = _get_java_tool_options(http_proxy, https_proxy, no_proxy)
+
+    if http_proxy or https_proxy:
+        env.update(
+            {
+                "HTTP_PROXY": http_proxy,
+                "HTTPS_PROXY": https_proxy,
+                "NO_PROXY": no_proxy,
+                "http_proxy": http_proxy,
+                "https_proxy": https_proxy,
+                "no_proxy": no_proxy,
+                "JAVA_TOOL_OPTIONS": java_tool_options,
+                "JOB_DEFAULT_ENV_http_proxy": http_proxy,
+                "JOB_DEFAULT_ENV_https_proxy": https_proxy,
+                "JOB_DEFAULT_ENV_no_proxy": no_proxy,
+                "JOB_DEFAULT_ENV_HTTP_PROXY": http_proxy,
+                "JOB_DEFAULT_ENV_HTTPS_PROXY": https_proxy,
+                "JOB_DEFAULT_ENV_NO_PROXY": no_proxy,
+                "JOB_DEFAULT_ENV_JAVA_TOOL_OPTIONS": java_tool_options,
+            }
+        )
+
+    return env
+
+
+def _get_java_tool_options(http_proxy, https_proxy, no_proxy):
+    options = ""
+    if http_proxy:
+        _, host, port = _split_url(http_proxy)
+        options += f"-Dhttp.proxyHost={host} -Dhttp.proxyPort={port}"
+    if https_proxy:
+        _, host, port = _split_url(https_proxy)
+        options += f" -Dhttps.proxyHost={host} -Dhttps.proxyPort={port}"
+    if no_proxy:
+        options += f" -Dhttp.nonProxyHosts={no_proxy.replace(',', '|')}"
+
+    return options
+
+
+def _split_url(url):
+    parsed_url = urlparse(url)
+    protocol = parsed_url.scheme
+    host = parsed_url.hostname
+    port = parsed_url.port
+    return protocol, host, port
+
+
+def construct_svc_endpoint(service_name, namespace, port, secure=False):
+    """Construct the endpoint for a Kubernetes service.
+
+    Args:
+        service_name (str): The name of the Kubernetes service.
+        namespace (str): The namespace of the Kubernetes service.
+        port (int): The port number of the Kubernetes service.
+        secure (bool): Whether to use HTTPS (true) or HTTP (false).
+
+    Returns:
+        str: The constructed S3 service endpoint.
+    """
+    protocol = "https" if secure else "http"
+    return f"{protocol}://{service_name}.{namespace}.svc.cluster.local:{port}"

--- a/src/charm_helpers.py
+++ b/src/charm_helpers.py
@@ -24,6 +24,7 @@ def create_env(model_name, app_name, config, state):
     db_name = db_conn["dbname"]
     db_url = f"jdbc:postgresql://{host}:{port}/{db_name}"
 
+    # Some defaults are extracted from Helm chart: https://github.com/airbytehq/airbyte-platform/tree/v0.57.3/charts/airbyte
     env = {
         "API_URL": "/api/v1/",
         "AIRBYTE_VERSION": AIRBYTE_VERSION,

--- a/src/literals.py
+++ b/src/literals.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Literals."""
+
+# TODO (kelkawi-a): perform up check on the following ports for each container
+CONTAINERS = {
+    "airbyte-api-server": 8006,
+    "airbyte-bootloader": None,
+    "airbyte-connector-builder-server": 8080,
+    "airbyte-cron": 9001,
+    "airbyte-pod-sweeper": None,
+    "airbyte-server": 8001,
+    "airbyte-workers": 9000,
+}
+
+DB_NAME = "airbyte-k8s_db"
+CONNECTOR_BUILDER_SERVER_API_PORT = 80
+INTERNAL_API_PORT = 8001
+AIRBYTE_API_PORT = 8006
+WORKLOAD_API_PORT = 8007
+REQUIRED_MINIO_CONFIG = ["minio-host", "minio-access-key", "minio-secret-key"]
+REQUIRED_S3_PARAMETERS = ["region", "endpoint", "access-key", "secret-key"]
+AIRBYTE_VERSION = "0.57.3"
+BUCKET_CONFIGS = [
+    "storage-bucket-logs",
+    "storage-bucket-state",
+    "storage-bucket-activity-payload",
+    "storage-bucket-workload-output",
+]
+LOGS_BUCKET_CONFIG = "storage-bucket-logs"

--- a/src/relations/airbyte_ui.py
+++ b/src/relations/airbyte_ui.py
@@ -12,7 +12,7 @@ from ops.model import ActiveStatus
 logger = logging.getLogger(__name__)
 
 
-class AirbyteServer(framework.Object):
+class AirbyteServerProvider(framework.Object):
     """Client for server:ui relation."""
 
     def __init__(self, charm):

--- a/src/relations/airbyte_ui.py
+++ b/src/relations/airbyte_ui.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the Airbyte server:ui relation."""
+
+import logging
+
+from log import log_event_handler
+from ops import framework
+from ops.model import ActiveStatus
+
+logger = logging.getLogger(__name__)
+
+
+class AirbyteServer(framework.Object):
+    """Client for server:ui relation."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "airbyte-server")
+        self.charm = charm
+        charm.framework.observe(
+            charm.on.airbyte_server_relation_joined, self._on_airbyte_server_relation_joined
+        )
+        charm.framework.observe(
+            charm.on.airbyte_server_relation_changed, self._on_airbyte_server_relation_joined
+        )
+
+    @log_event_handler(logger)
+    def _on_airbyte_server_relation_joined(self, event):
+        """Handle new server:ui relation.
+
+        Attempt to provide server status to the ui application.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if self.charm.unit.is_leader():
+            self._provide_server_status()
+
+    def _provide_server_status(self):
+        """Provide server status to the UI charm."""
+        is_active = self.charm.model.unit.status == ActiveStatus()
+
+        ui_relations = self.charm.model.relations["airbyte-server"]
+        if not ui_relations:
+            logger.debug("server:ui: not providing server status: ui not ready")
+            return
+        for relation in ui_relations:
+            logger.debug(f"server:ui: providing server status on relation {relation.id}")
+            relation.data[self.charm.app].update(
+                {
+                    "server_name": self.charm.app.name,
+                    "server_status": "ready" if is_active else "blocked",
+                }
+            )

--- a/src/relations/minio.py
+++ b/src/relations/minio.py
@@ -1,0 +1,123 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the Airbyte server minio relation."""
+
+import logging
+
+from charm_helpers import construct_svc_endpoint
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from log import log_event_handler
+from ops import framework
+from ops.model import BlockedStatus, WaitingStatus
+from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
+
+logger = logging.getLogger(__name__)
+
+
+class MinioRelation(framework.Object):
+    """Client for airbyte:minio relation."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "object-storage")
+        self.charm = charm
+
+        # Handle minio relation.
+        charm.framework.observe(
+            charm.on.object_storage_relation_joined, self._on_object_storage_relation_changed
+        )
+        charm.framework.observe(
+            charm.on.object_storage_relation_changed, self._on_object_storage_relation_changed
+        )
+        charm.framework.observe(
+            charm.on.object_storage_relation_broken, self._on_object_storage_relation_broken
+        )
+
+    @log_event_handler(logger)
+    def _on_object_storage_relation_changed(self, event):
+        """Handle changing object-storage relation.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        try:
+            interfaces = self._get_interfaces()
+            storage_data = self._get_object_storage_data(interfaces)
+            endpoint = construct_svc_endpoint(
+                storage_data["service"],
+                storage_data["namespace"],
+                storage_data["port"],
+                storage_data["secure"],
+            )
+
+            self.charm._state.minio = {
+                **storage_data,
+                "endpoint": endpoint,
+            }
+            self.charm._update(event)
+        except ErrorWithStatus as err:
+            self.charm.unit.status = err.status
+            logging.info(f"Event {event} stopped early with message: {str(err)}")
+            return
+
+    @log_event_handler(logger)
+    def _on_object_storage_relation_broken(self, event) -> None:
+        """Handle broken relation with object-storage.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        self.charm._state.minio = None
+        self.charm._update(event)
+
+    def _get_interfaces(self):
+        """Retrieve interface object."""
+        try:
+            charm = self.charm
+            # Hack: get_interfaces checks for peer relation which does not exist under requires/provides list in charmcraft.yaml
+            del charm.meta.relations["peer"]
+            interfaces = get_interfaces(charm)
+        except NoVersionsListed as err:
+            raise ErrorWithStatus(err, WaitingStatus)
+        except NoCompatibleVersions as err:
+            raise ErrorWithStatus(err, BlockedStatus)
+        return interfaces
+
+    def _get_object_storage_data(self, interfaces):
+        """Unpacks and returns the object-storage relation data.
+
+        Raises CheckFailedError if an anticipated error occurs.
+        """
+        if not ((obj_storage := interfaces["object-storage"]) and obj_storage.get_data()):
+            raise ErrorWithStatus("Waiting for object-storage relation data", WaitingStatus)
+
+        try:
+            logging.info(f"obj_storage get_data: {obj_storage.get_data()}")
+            obj_storage = list(obj_storage.get_data().values())[0]
+        except Exception as e:
+            raise ErrorWithStatus(
+                f"Unexpected error unpacking object storage data - data format not "
+                f"as expected. Caught exception: '{str(e)}'",
+                BlockedStatus,
+            )
+
+        return obj_storage

--- a/src/relations/minio.py
+++ b/src/relations/minio.py
@@ -69,7 +69,7 @@ class MinioRelation(framework.Object):
             self.charm._update(event)
         except ErrorWithStatus as err:
             self.charm.unit.status = err.status
-            logging.info(f"Event {event} stopped early with message: {str(err)}")
+            logger.error(f"Event {event} stopped early with message: {str(err)}")
             return
 
     @log_event_handler(logger)
@@ -111,7 +111,7 @@ class MinioRelation(framework.Object):
             raise ErrorWithStatus("Waiting for object-storage relation data", WaitingStatus)
 
         try:
-            logging.info(f"obj_storage get_data: {obj_storage.get_data()}")
+            logger.info(f"obj_storage get_data: {obj_storage.get_data()}")
             obj_storage = list(obj_storage.get_data().values())[0]
         except Exception as e:
             raise ErrorWithStatus(

--- a/src/relations/postgresql.py
+++ b/src/relations/postgresql.py
@@ -1,0 +1,75 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define the Airbyte server postgresql relation."""
+
+import logging
+
+from charms.data_platform_libs.v0.database_requires import DatabaseEvent
+from literals import DB_NAME
+from log import log_event_handler
+from ops import framework
+from ops.model import WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresqlRelation(framework.Object):
+    """Client for airbyte:postgresql relations."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "db")
+        self.charm = charm
+
+        charm.framework.observe(charm.db.on.database_created, self._on_database_changed)
+        charm.framework.observe(charm.db.on.endpoints_changed, self._on_database_changed)
+        charm.framework.observe(charm.on.db_relation_broken, self._on_database_relation_broken)
+
+    @log_event_handler(logger)
+    def _on_database_changed(self, event: DatabaseEvent) -> None:
+        """Handle database creation/change events.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        self.charm.unit.status = WaitingStatus(f"handling {event.relation.name} change")
+        host, port = event.endpoints.split(",", 1)[0].split(":")
+
+        self.charm._state.database_connection = {
+            "dbname": DB_NAME,
+            "host": host,
+            "port": port,
+            "password": event.password,
+            "user": event.username,
+        }
+
+        self.charm._update(event)
+
+    @log_event_handler(logger)
+    def _on_database_relation_broken(self, event: DatabaseEvent) -> None:
+        """Handle broken relations with the database.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        if not self.charm._state.is_ready():
+            event.defer()
+            return
+
+        self.charm._state.database_connection = None
+        self.charm._update(event)

--- a/src/relations/s3.py
+++ b/src/relations/s3.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""S3 relation implementation."""
+
+import logging
+
+import botocore
+from charms.data_platform_libs.v0.s3 import (
+    CredentialsChangedEvent,
+    CredentialsGoneEvent,
+)
+from log import log_event_handler
+from ops import framework
+
+logger = logging.getLogger(__name__)
+
+
+class S3Integrator(framework.Object):
+    """Client for s3:temporal relation."""
+
+    def __init__(self, charm):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        super().__init__(charm, "s3")
+        self.charm = charm
+        charm.framework.observe(
+            charm.s3_client.on.credentials_changed, self._on_s3_credentials_changed
+        )
+        charm.framework.observe(charm.s3_client.on.credentials_gone, self._on_s3_credentials_gone)
+
+    @log_event_handler(logger)
+    def _on_s3_credentials_changed(self, event: CredentialsChangedEvent):
+        """Handle new s3:temporal relation.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        s3_parameters, missing_parameters = self._retrieve_s3_parameters()
+        if missing_parameters:
+            return
+
+        endpoint = _construct_endpoint(s3_parameters)
+        self.charm._state.s3 = {
+            "bucket": s3_parameters.get("bucket"),
+            "endpoint": endpoint,
+            "region": s3_parameters.get("region"),
+            "access-key": s3_parameters.get("access-key"),
+            "secret-key": s3_parameters.get("secret-key"),
+            "uri_style": s3_parameters.get("s3-uri-style"),
+        }
+        self.charm._update(event)
+
+    @log_event_handler(logger)
+    def _on_s3_credentials_gone(self, event: CredentialsGoneEvent) -> None:
+        """Handle s3:temporal relation broken event.
+
+        Args:
+            event: The event triggered when the relation was broken.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        self.charm._state.s3 = None
+        self.charm._update(event)
+
+    def _retrieve_s3_parameters(self):
+        """Retrieve S3 parameters from the S3 integrator relation.
+
+        Returns:
+            s3 parameters (dict) and any missing parameters (list) from the relation.
+        """
+        s3_parameters = self.charm.s3_client.get_s3_connection_info()
+        required_parameters = [
+            "access-key",
+            "secret-key",
+        ]
+        missing_required_parameters = [
+            param for param in required_parameters if param not in s3_parameters
+        ]
+        if missing_required_parameters:
+            logger.warning(
+                f"Missing required S3 parameters in relation with S3 integrator: {missing_required_parameters}"
+            )
+            return {}, missing_required_parameters
+
+        # Add some sensible defaults (as expected by the code) for missing optional parameters
+        s3_parameters.setdefault("endpoint", "https://s3.amazonaws.com")
+        s3_parameters.setdefault("region", "")
+        s3_parameters.setdefault("path", "")
+        s3_parameters.setdefault("s3-uri-style", "host")
+
+        # Strip whitespaces from all parameters.
+        for key, value in s3_parameters.items():
+            if isinstance(value, str):
+                s3_parameters[key] = value.strip()
+
+        # Clean up extra slash symbols to avoid issues on 3rd-party storages
+        # like Ceph Object Gateway (radosgw).
+        s3_parameters["endpoint"] = s3_parameters["endpoint"].rstrip("/")
+        s3_parameters["path"] = (
+            f'/{s3_parameters["path"].strip("/")}'  # The slash in the beginning is required by pgBackRest.
+        )
+        s3_parameters["bucket"] = s3_parameters["bucket"].strip("/")
+
+        return s3_parameters, []
+
+
+def _construct_endpoint(s3_parameters):
+    """Construct the S3 service endpoint using the region.
+
+    This is needed when the provided endpoint is from AWS, and it doesn't contain the region.
+
+    Args:
+        s3_parameters: s3 parameters fetched from the s3 integrator relation.
+
+    Returns:
+        S3 service endpoint.
+    """
+    # Use the provided endpoint if a region is not needed.
+    endpoint = s3_parameters["endpoint"]
+
+    # Load endpoints data.
+    loader = botocore.loaders.create_loader()
+    data = loader.load_data("endpoints")
+
+    # Construct the endpoint using the region.
+    resolver = botocore.regions.EndpointResolver(data)
+    endpoint_data = resolver.construct_endpoint("s3", s3_parameters["region"])
+
+    # Use the built endpoint if it is an AWS endpoint.
+    if endpoint_data and endpoint.endswith(endpoint_data["dnsSuffix"]):
+        endpoint = f'{endpoint.split("://")[0]}://{endpoint_data["hostname"]}'
+
+    return endpoint

--- a/src/s3_helpers.py
+++ b/src/s3_helpers.py
@@ -1,0 +1,92 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""S3 helpers."""
+
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+class S3Client:
+    """Client for S3 operations."""
+
+    def __init__(self, s3_parameters):
+        """Construct.
+
+        Args:
+            charm: The charm to attach the hooks to.
+        """
+        endpoint = s3_parameters.get("endpoint")
+        session = boto3.session.Session(
+            aws_access_key_id=s3_parameters.get("access-key"),
+            aws_secret_access_key=s3_parameters.get("secret-key"),
+            region_name=s3_parameters.get("region"),  # Region can be optional for MinIO
+        )
+        self.s3_parameters = s3_parameters
+        try:
+            self.s3_resource = session.resource("s3", endpoint_url=endpoint)
+            self.s3_client = session.client("s3", endpoint_url=endpoint)
+        except ValueError as e:
+            logger.exception(
+                "Failed to create a session in region=%s.", s3_parameters.get("region")
+            )
+            raise e
+
+    def create_bucket_if_not_exists(self, bucket_name):
+        """Create the S3 bucket if it does not exist.
+
+        Args:
+            s3_parameters: S3 parameters fetched from the S3 integrator relation.
+            endpoint: S3 service endpoint.
+
+        Raises:
+            e (ValueError): if a session could not be created.
+            error (ClientError): if the bucket could not be created.
+        """
+        region = self.s3_parameters.get("region")
+        s3_bucket = self.s3_resource.Bucket(bucket_name)
+        try:
+            s3_bucket.meta.client.head_bucket(Bucket=bucket_name)
+            logger.info("Bucket %s exists.", bucket_name)
+            exists = True
+        except ClientError as e:
+            error_code = int(e.response["Error"]["Code"])
+            if error_code == 404:
+                logger.warning(
+                    "Bucket %s doesn't exist or you don't have access to it.", bucket_name
+                )
+                exists = False
+            else:
+                logger.exception("Unexpected error: %s", e)
+                raise
+
+        if not exists:
+            try:
+                create_bucket_configuration = {}
+                s3_bucket.create()
+                s3_bucket.wait_until_exists()
+                logger.info("Created bucket '%s' in region=%s", bucket_name, region)
+            except ClientError as error:
+                logger.exception(
+                    "Couldn't create bucket named '%s' in region=%s.", bucket_name, region
+                )
+                raise error
+
+    def set_bucket_lifecycle_policy(self, bucket, ttl):
+        lifecycle_policy = {
+            "Rules": [
+                {
+                    "Expiration": {"Days": ttl},
+                    "Filter": {"Prefix": ""},
+                    "Status": "Enabled",
+                    "ID": "ttl",
+                }
+            ]
+        }
+        self.s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket, LifecycleConfiguration=lifecycle_policy
+        )

--- a/src/s3_helpers.py
+++ b/src/s3_helpers.py
@@ -66,7 +66,6 @@ class S3Client:
 
         if not exists:
             try:
-                create_bucket_configuration = {}
                 s3_bucket.create()
                 s3_bucket.wait_until_exists()
                 logger.info("Created bucket '%s' in region=%s", bucket_name, region)

--- a/src/scripts/pod-sweeper.sh
+++ b/src/scripts/pod-sweeper.sh
@@ -48,23 +48,15 @@ do
         echo "Evaluating pod: $POD_NAME with status $POD_STATUS since $POD_DATE_STR"
 
         if [ -n "${RUNNING_TTL_MINUTES}" ] && [ "$POD_STATUS" = "Running" ]; then
-            echo "TEST 5"
             if [ "$POD_DATE" -lt "$RUNNING_DATE" ]; then
-                echo "TEST 6"
                 delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
             fi
         elif [ -n "${SUCCEEDED_TTL_MINUTES}" ] && ([[ "$POD_STATUS" = "Succeeded" ]] || [[ "$POD_STATUS" = "Completed" ]]); then
-            echo "TEST 1"
-            echo "$POD_DATE"
-            echo "$SUCCESS_DATE"
             if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
-                echo "TEST 2"
                 delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
             fi
         elif [ -n "${UNSUCCESSFUL_TTL_MINUTES}" ] && [ "$POD_STATUS" != "Running" ] && [ "$POD_STATUS" != "Succeeded" ]; then
-            echo "TEST 3"
             if [ "$POD_DATE" -lt "$NON_SUCCESS_DATE" ]; then
-                echo "TEST 4"
                 delete_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
             fi
         fi

--- a/src/structured_config.py
+++ b/src/structured_config.py
@@ -26,7 +26,8 @@ class LogLevelType(str, Enum):
 class StorageType(str, Enum):
     """Enum for the `storage-type` field."""
 
-    minio = "minio"
+    minio = "MINIO"
+    s3 = "S3"
 
 
 class CharmConfig(BaseConfigModel):
@@ -35,7 +36,8 @@ class CharmConfig(BaseConfigModel):
     log_level: LogLevelType
     temporal_host: str
     storage_type: StorageType
-    storage_bucket_log: str
+    storage_bucket_logs: str
+    logs_ttl: int
     storage_bucket_state: str
     storage_bucket_activity_payload: str
     storage_bucket_workload_output: str
@@ -62,7 +64,7 @@ class CharmConfig(BaseConfigModel):
         "pod_running_ttl_minutes", "pod_successful_ttl_minutes", "pod_unsuccessful_ttl_minutes"
     )
     @classmethod
-    def ttl_minutes_validator(cls, value: str) -> Optional[int]:
+    def pod_ttl_minutes_validator(cls, value: str) -> Optional[int]:
         """Check validity of `*-ttl-minutes` fields.
 
         Args:
@@ -76,5 +78,24 @@ class CharmConfig(BaseConfigModel):
         """
         int_value = int(value)
         if int_value > 0:
+            return int_value
+        raise ValueError("Value out of range.")
+
+    @validator("logs_ttl")
+    @classmethod
+    def logs_ttl_validator(cls, value: str) -> Optional[int]:
+        """Check validity of `logs-ttl` fields.
+
+        Args:
+            value: logs-ttl value
+
+        Returns:
+            int_value: integer for logs-ttl configuration
+
+        Raises:
+            ValueError: in the case when the value is out of range
+        """
+        int_value = int(value)
+        if int_value >= 0:
             return int_value
         raise ValueError("Value out of range.")


### PR DESCRIPTION
This PR does the following:

- Adds a relation to the [PostgreSQL charm](https://charmhub.io/postgresql-k8s) to act as Airbyte's DB.
- Adds a relation to the [Minio charm](https://charmhub.io/minio) as an option for object storage.
- Adds a relation to the [S3 integrator charm](https://charmhub.io/s3-integrator) as another option for object storage.
- Adds a relation to the [Airbyte UI charm](https://github.com/canonical/airbyte-ui-k8s-operator) to enable communication of server status and service name between the two. The corresponding UI PR can be found [here](https://github.com/canonical/airbyte-ui-k8s-operator/pull/5).
- Adds a configuration value for logs TTL, which gets added as a lifecycle policy for the selected object storage bucket.
- Adds logic for creating object storage buckets on Minio/S3 storage on relation creation or on config change.
- Refactors charm code.


Note: I've tested the functionality of adding source and destination connectors, and running a sync job. The only shortcoming thus far is that I am not able to get the Airbyte worker to store the logs in object storage (the bucket creation at the charm level works, Airbyte is just not communicating with the object storage properly to upload the logs). I am currently investigating this issue on different Airbyte slack channels and threads [[1](https://github.com/airbytehq/airbyte/issues/36826),[2](https://github.com/airbytehq/airbyte/issues/34512),[3](https://github.com/airbytehq/airbyte/issues/34539)]. I have also tested the S3 integration with RadosGW, but Airbyte seems to have hardcoded this to AWS S3 storage, not just any S3-compatible storage. Regardless, this PR can be considered ready for review, with minor fixes to come potentially on some environment variables later.