### PR TITLE
Add docs link

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-and-publish-charm:
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     secrets: inherit
     with:
       channel: latest/edge

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ operators can be deployed and connected to each other using the Juju command
 line as follows:
 
 ```bash
-juju deploy airbyte-k8s --trust
+juju deploy airbyte-k8s --channel edge --trust
 juju deploy postgresql-k8s --channel 14/edge --trust
 juju relate airbyte-k8s postgresql-k8s
 ```
@@ -83,7 +83,7 @@ Once the Airbyte UI operator is deployed, it can be connected to the Airbyte
 operator using the Juju command line as follows:
 
 ```bash
-juju deploy airbyte-ui-k8s
+juju deploy airbyte-ui-k8s --channel edge
 juju relate airbyte-k8s airbyte-ui-k8s
 ```
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,6 +13,9 @@ description: |
   streamline the process of extracting and loading data from various sources into 
   data warehouses, lakes, or other destinations.
 
+links:
+  documentation: https://discourse.charmhub.io/t/charmed-airbyte-k8s-overview/14530
+
 # (Required for 'charm' type)
 bases:
   - build-on:


### PR DESCRIPTION
This PR adds a link to the Charmhub docs in `charmcraft.yaml` and updates the `publish_charm` workflow to an older version which does not require images to be present in the repo.