### PR TITLE
Unpin publish charm workflow version

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-and-publish-charm:
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
       channel: latest/edge


### PR DESCRIPTION
This PR unpins the `publish_charm` workflow version made in #13 as it seems to also fail. The latest version of the `operator-workflows` following the merging of [this PR](https://github.com/canonical/operator-workflows/pull/364) should fix the issue.