### PR TITLE
fix[CSS-23490]: unblock rock build and integration-test pipeline

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,10 @@ concurrency:
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,14 +7,13 @@ concurrency:
 on:
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write
     with:
       channel: 1.34-strict/stable
       modules: '["test_charm.py"]'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,10 @@ name: Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@cea2ac306b4f4c1475d73b1a4c766d62e5b1c8a9

--- a/airbyte_rock/rockcraft.yaml
+++ b/airbyte_rock/rockcraft.yaml
@@ -75,6 +75,16 @@ parts:
       - libpq-dev
       - python3-dev
     override-build: |
+      # jOOQ codegen in `assemble` uses Testcontainers, whose docker-java client 
+      # speaks API 1.32. The docker snap ships Docker >=28 (min API 1.40) and rejects it. 
+      # Lower the daemon's min API version so the old client is accepted.
+      mkdir -p /etc/systemd/system/snap.docker.dockerd.service.d
+      printf '[Service]\nEnvironment=DOCKER_MIN_API_VERSION=1.24\n' \
+        > /etc/systemd/system/snap.docker.dockerd.service.d/min-api-version.conf
+      systemctl daemon-reload
+      systemctl restart snap.docker.dockerd
+      timeout 120 bash -c 'until docker version >/dev/null 2>&1; do sleep 2; done'
+
       cd ${CRAFT_STAGE}/airbyte-platform
       ./gradlew assemble -x dockerBuildImage --continue --max-workers 1
       ./gradlew --stop

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,21 +50,12 @@ async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
     resources = {"airbyte-image": charm_image}
 
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME_AIRBYTE_SERVER, trust=True)
-    # The bare `edge` channel resolved to 1.23/edge rev 68 (base 24.04),
-    # whose image resource juju could not fetch ("No revision was found in
-    # the Store"). edge and stable share rev 68 on 24.04, so forcing base
-    # 22.04 selects a different revision (rev 60) to probe instead.
     await ops_test.model.deploy(
         APP_NAME_TEMPORAL_SERVER,
-        channel="1.23/stable",
-        base="ubuntu@22.04",
+        channel="edge",
         config={"num-history-shards": 4},
     )
-    await ops_test.model.deploy(
-        APP_NAME_TEMPORAL_ADMIN,
-        channel="1.23/stable",
-        base="ubuntu@22.04",
-    )
+    await ops_test.model.deploy(APP_NAME_TEMPORAL_ADMIN, channel="edge")
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
     await ops_test.model.deploy("minio", channel="edge")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,14 +50,20 @@ async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
     resources = {"airbyte-image": charm_image}
 
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME_AIRBYTE_SERVER, trust=True)
-    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
-    await ops_test.model.deploy("minio", channel="edge")
     await ops_test.model.deploy(
         APP_NAME_TEMPORAL_SERVER,
-        channel="edge",
+        channel="1.23/edge",
+        base="ubuntu@24.04",
         config={"num-history-shards": 4},
     )
-    await ops_test.model.deploy(APP_NAME_TEMPORAL_ADMIN, channel="edge")
+    await ops_test.model.deploy(
+        APP_NAME_TEMPORAL_ADMIN,
+        channel="1.23/edge",
+        base="ubuntu@24.04",
+    )
+
+    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
+    await ops_test.model.deploy("minio", channel="edge")
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,12 +50,21 @@ async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
     resources = {"airbyte-image": charm_image}
 
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME_AIRBYTE_SERVER, trust=True)
+    # The bare `edge` channel resolved to 1.23/edge rev 68 (base 24.04),
+    # whose image resource juju could not fetch ("No revision was found in
+    # the Store"). edge and stable share rev 68 on 24.04, so forcing base
+    # 22.04 selects a different revision (rev 60) to probe instead.
     await ops_test.model.deploy(
         APP_NAME_TEMPORAL_SERVER,
-        channel="edge",
+        channel="1.23/stable",
+        base="ubuntu@22.04",
         config={"num-history-shards": 4},
     )
-    await ops_test.model.deploy(APP_NAME_TEMPORAL_ADMIN, channel="edge")
+    await ops_test.model.deploy(
+        APP_NAME_TEMPORAL_ADMIN,
+        channel="1.23/stable",
+        base="ubuntu@22.04",
+    )
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
     await ops_test.model.deploy("minio", channel="edge")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,14 +50,14 @@ async def deploy(ops_test: OpsTest, charm: str, charm_image: str):
     resources = {"airbyte-image": charm_image}
 
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME_AIRBYTE_SERVER, trust=True)
+    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
+    await ops_test.model.deploy("minio", channel="edge")
     await ops_test.model.deploy(
         APP_NAME_TEMPORAL_SERVER,
         channel="edge",
         config={"num-history-shards": 4},
     )
     await ops_test.model.deploy(APP_NAME_TEMPORAL_ADMIN, channel="edge")
-    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True, revision=381)
-    await ops_test.model.deploy("minio", channel="edge")
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -48,19 +48,19 @@ async def run_sample_workflow(ops_test: OpsTest):
 
 
 async def create_default_namespace(ops_test: OpsTest):
-    """Create default namespace on Temporal server using tctl.
+    """Create the default namespace on the Temporal server.
 
     Args:
         ops_test: PyTest object.
     """
-    # Register default namespace from admin charm.
+    # Register the default namespace from the admin charm.
     action = (
         await ops_test.model.applications[APP_NAME_TEMPORAL_ADMIN]
         .units[0]
-        .run_action("tctl", args="--ns default namespace register -rd 3")
+        .run_action("cli", args="operator namespace --namespace default create")
     )
     result = (await action.wait()).results
-    logger.info(f"tctl result: {result}")
+    logger.info(f"cli result: {result}")
     assert "result" in result and result["result"] == "command succeeded"
 
 
@@ -107,6 +107,11 @@ async def perform_temporal_integrations(ops_test: OpsTest):
     await ops_test.model.integrate(f"{APP_NAME_TEMPORAL_SERVER}:db", "postgresql-k8s:database")
     await ops_test.model.integrate(f"{APP_NAME_TEMPORAL_SERVER}:visibility", "postgresql-k8s:database")
     await ops_test.model.integrate(f"{APP_NAME_TEMPORAL_SERVER}:admin", f"{APP_NAME_TEMPORAL_ADMIN}:admin")
+    # The admin charm's `cli` action resolves the server address via the
+    # temporal-host-info relation; without it the action fails.
+    await ops_test.model.integrate(
+        f"{APP_NAME_TEMPORAL_SERVER}:temporal-host-info", f"{APP_NAME_TEMPORAL_ADMIN}:temporal-host-info"
+    )
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME_TEMPORAL_SERVER, "postgresql-k8s"], status="active", raise_on_blocked=False, timeout=180
     )

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,6 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.5.2.1
     pytest==7.1.3
     pytest-operator==0.35.0
     temporalio==1.6.0


### PR DESCRIPTION
This PR fixes the CI failures blocking the rock charm's build and integration tests.

- **Rock build:** set `DOCKER_MIN_API_VERSION=1.24` so Airbyte's jOOQ Testcontainers (docker-java API 1.32) is accepted by the Docker ≥28 daemon during `gradlew assemble`.
- **CI permissions:** grant `packages: write` (push the built rock to GHCR) and `pull-requests: write` (charm-library check).
- **Integration tests:** pin `temporal-k8s`/`temporal-admin-k8s` to `1.23/edge` on `ubuntu@24.04`, replace the removed `tctl` action with `cli`, add the now-required `temporal-host-info` relation, and drop the stale `juju` client pin in `tox.ini`.