### PR TITLE
Update integration_test.yaml with permissions

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,10 @@ concurrency:
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main


### PR DESCRIPTION
Add permissions for contents and pull-requests in integration test workflow. This will need to be merged in red as it will unblock the building of the rock image.