### PR TITLE
feat[CSS-22878]: adopt the standard ingress interface

### DIFF
--- a/airbyte_rock/rockcraft.yaml
+++ b/airbyte_rock/rockcraft.yaml
@@ -75,23 +75,23 @@ parts:
       - libpq-dev
       - python3-dev
     override-build: |
-      # jOOQ codegen in `assemble` uses Testcontainers, whose docker-java client 
-      # speaks API 1.32. The docker snap ships Docker >=28 (min API 1.40) and rejects it. 
+      # jOOQ codegen in `assemble` uses Testcontainers, whose docker-java client
+      # speaks API 1.32. The docker snap ships Docker >=28 (min API 1.40) and rejects it.
       # Lower the daemon's min API version so the old client is accepted.
       mkdir -p /etc/systemd/system/snap.docker.dockerd.service.d
       printf '[Service]\nEnvironment=DOCKER_MIN_API_VERSION=1.24\n' \
         > /etc/systemd/system/snap.docker.dockerd.service.d/min-api-version.conf
+
+      # Route the daemon's Docker Hub pulls through Canonical's internal pull-through
+      # cache so Testcontainers' pulls (postgres:15-alpine, ryuk) don't hit Docker Hub's
+      # anonymous rate limit on the shared runners' egress IPs.
+      mkdir -p /var/snap/docker/current/config
+      echo '{"registry-mirrors": ["https://github-runner-dockerhub-cache.canonical.com:5000"]}' \
+        > /var/snap/docker/current/config/daemon.json
+
       systemctl daemon-reload
       systemctl restart snap.docker.dockerd
       timeout 120 bash -c 'until docker version >/dev/null 2>&1; do sleep 2; done'
-
-      # jOOQ's Testcontainers pulls postgres:15-alpine, tripping 
-      # Docker Hub's anonymous pull-rate limit on shared runners; 
-      # resolve to using the AWS ECR Public mirror.
-      export TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=public.ecr.aws/docker/library/
-      # Ryuk isn't a library/ image (can't use the mirror); the build is
-      # ephemeral, so it's disabled.
-      export TESTCONTAINERS_RYUK_DISABLED=true
 
       cd ${CRAFT_STAGE}/airbyte-platform
       ./gradlew assemble -x dockerBuildImage --continue --max-workers 1

--- a/airbyte_rock/rockcraft.yaml
+++ b/airbyte_rock/rockcraft.yaml
@@ -85,6 +85,14 @@ parts:
       systemctl restart snap.docker.dockerd
       timeout 120 bash -c 'until docker version >/dev/null 2>&1; do sleep 2; done'
 
+      # jOOQ's Testcontainers pulls postgres:15-alpine, tripping 
+      # Docker Hub's anonymous pull-rate limit on shared runners; 
+      # resolve to using the AWS ECR Public mirror.
+      export TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=public.ecr.aws/docker/library/
+      # Ryuk isn't a library/ image (can't use the mirror); the build is
+      # ephemeral, so it's disabled.
+      export TESTCONTAINERS_RYUK_DISABLED=true
+
       cd ${CRAFT_STAGE}/airbyte-platform
       ./gradlew assemble -x dockerBuildImage --continue --max-workers 1
       ./gradlew --stop

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -90,6 +90,11 @@ requires:
     limit: 1
     optional: true
 
+  ingress:
+    interface: ingress
+    limit: 1
+    optional: true
+
 provides:
   airbyte-server:
     interface: airbyte-server

--- a/documentation/how-to/secure-airbyte-deployments.md
+++ b/documentation/how-to/secure-airbyte-deployments.md
@@ -49,7 +49,7 @@ For self-signed certificates you can do the following:
    here, but any compatible ingress provider (e.g. Traefik) works the same way:
 
    ```bash
-   juju relate airbyte-k8s nginx-ingress-integrator
+   juju integrate airbyte-k8s nginx-ingress-integrator
    ```
 
 **Note:** If you have a production-grade certificate, skip to step 3.

--- a/documentation/how-to/secure-airbyte-deployments.md
+++ b/documentation/how-to/secure-airbyte-deployments.md
@@ -44,10 +44,12 @@ For self-signed certificates you can do the following:
    juju config airbyte-k8s external-hostname=<YOUR_HOSTNAME>
    ```
 
-5. Finally, relate Airbyte with the Nginx Ingress Integrator to create your ingress resource:
+5. Finally, integrate Airbyte with the ingress provider over the standard `ingress`
+   interface to create your ingress resource. The Nginx Ingress Integrator is used
+   here, but any compatible ingress provider (e.g. Traefik) works the same way:
 
    ```bash
-   juju relate airbyte-k8s nginx-ingress-integrator
+   juju integrate airbyte-k8s nginx-ingress-integrator
    ```
 
 **Note:** If you have a production-grade certificate, skip to step 3.

--- a/documentation/how-to/secure-airbyte-deployments.md
+++ b/documentation/how-to/secure-airbyte-deployments.md
@@ -49,7 +49,7 @@ For self-signed certificates you can do the following:
    here, but any compatible ingress provider (e.g. Traefik) works the same way:
 
    ```bash
-   juju integrate airbyte-k8s nginx-ingress-integrator
+   juju relate airbyte-k8s nginx-ingress-integrator
    ```
 
 **Note:** If you have a production-grade certificate, skip to step 3.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -18,7 +18,7 @@ It is intended for **data engineers and platform teams** who want to automate an
 - Automated deployment and scaling on Kubernetes
 - Seamless integration with PostgreSQL, Temporal, and object storage via Juju relations
 - Simple Airbyte UI access for connector configuration and monitoring
-- Ingress and authentication integration via Nginx and OAuth2 Proxy charms
+- Ingress via the standard `ingress` interface (compatible with any ingress provider, such as Nginx Ingress Integrator or Traefik) and authentication via the OAuth2 Proxy charm
 - Observability through Juju relation-based configuration
 
 ## In this documentation

--- a/documentation/reference/architecture.md
+++ b/documentation/reference/architecture.md
@@ -8,7 +8,7 @@ The Charmed Airbyte ecosystem consists of a number of different charmed operator
 
 ### Airbyte-k8s
 
-The Airbyte-k8s charm is the core component that runs the server, scheduler, and API. It uses MinIO as its object storage backend and relies on a PostgreSQL database for persistent data. The charm integrates with OAuth2 Proxy to provide authentication capabilities, stores blobs, logs, and state in MinIO, and exposes its services through a nginx ingress integrator.
+The Airbyte-k8s charm is the core component that runs the server, scheduler, and API. It uses MinIO as its object storage backend and relies on a PostgreSQL database for persistent data. The charm integrates with OAuth2 Proxy to provide authentication capabilities, stores blobs, logs, and state in MinIO, and exposes its services through the standard `ingress` interface, which can be served by any compatible ingress provider (such as the Nginx Ingress Integrator or Traefik).
 
 ### OAuth2 Proxy
 

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,949 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops import EventBase
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 21
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:  # noqa
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore  # noqa
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")  # type: ignore
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,  # type: ignore
+            )
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: Optional[IngressUrl] = None
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+    is_port_open: bool = Field(default=False, description="Whether the port is open.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme: str) -> str:  # noqa: N805
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("port")
+    def validate_port(cls, port: int) -> int:  # noqa: N805
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("host")
+    def validate_host(cls, host: str) -> str:  # noqa: N805
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("ip")
+    def validate_ip(cls, ip: str) -> Optional[str]:  # noqa: N805
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):  # type: ignore
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):  # type: ignore
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> Dict[str, Any]:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: Any) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation) -> None:
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's unit databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(cast(IngressRequirerUnitData, data))
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return cast(IngressRequirerAppData, IngressRequirerAppData.load(databag))
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
+
+    def is_ready(self, relation: Optional[Relation] = None) -> bool:
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str) -> None:
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                (
+                    f"url was not published to ingress relation for {relation.app}."
+                    f"This error is likely due to an error or misconfiguration of the"
+                    "charm calling this library."
+                )
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    f"no app in relation {ingress_relation} when fetching proxied endpoints:"
+                    "skipping"
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = cast(IngressProviderAppData, ingress_data.ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+    _auto_data: Optional[Tuple[Optional[str], Optional[str], int]]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        # shall we switch to manually calling provide_ingress_requirements with all args when
+        # ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema.
+                The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check
+                        endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check
+                        endpoint.
+                    - "interval" (str): Frequency of the health check calls
+                        (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request
+                        (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's
+                    defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress
+                URL, or a string if the scheme is known and stable at charm initialization.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self) -> bool:
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self) -> None:
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ) -> None:
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ) -> None:
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            # Ignore pyright errors since pyright does not like aliases.
+            IngressRequirerAppData(  # type: ignore
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                is_port_open=port in {open_port.port for open_port in self.unit.opened_ports()},
+                strip_prefix=self._strip_prefix,  # type: ignore
+                redirect_https=self._redirect_https,  # type: ignore
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        ingress = cast(IngressProviderAppData, IngressProviderAppData.load(databag)).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/src/charm.py
+++ b/src/charm.py
@@ -166,7 +166,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         Args:
             event: The event triggered when the ingress URL becomes available.
         """
-        logger.info("Ingress is ready; Airbyte is reachable at %s", event.url)
+        self._update(event)
 
     @log_event_handler(logger)
     def _on_ingress_revoked(self, event):
@@ -175,7 +175,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         Args:
             event: The event triggered when the ingress relation is removed.
         """
-        logger.info("Ingress relation removed; Airbyte is no longer exposed via ingress")
+        self._update(event)
 
     @log_event_handler(logger)
     def _on_peer_relation_changed(self, event):

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ from botocore.exceptions import ClientError
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.data_platform_libs.v0.database_requires import DatabaseRequires
 from charms.data_platform_libs.v0.s3 import S3Requirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from kubernetes.client.exceptions import ApiException
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckStatus
@@ -140,6 +141,12 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         # Handle UI relation
         self.airbyte_ui = AirbyteServerProvider(self)
 
+        # Airbyte server serves from the root of its backend, so strip_prefix=True
+        # makes the ingress provider strip the per-app path prefix before forwarding.
+        self.ingress = IngressPerAppRequirer(self, port=INTERNAL_API_PORT, strip_prefix=True)
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+
         for container_name in CONTAINER_HEALTH_CHECK_MAP:
             self.framework.observe(self.on[container_name].pebble_ready, self._on_pebble_ready)
 
@@ -151,6 +158,24 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             event: The event triggered.
         """
         self._update(event)
+
+    @log_event_handler(logger)
+    def _on_ingress_ready(self, event):
+        """Handle the ingress-ready event.
+
+        Args:
+            event: The event triggered when the ingress URL becomes available.
+        """
+        logger.info("Ingress is ready; Airbyte is reachable at %s", event.url)
+
+    @log_event_handler(logger)
+    def _on_ingress_revoked(self, event):
+        """Handle the ingress-revoked event.
+
+        Args:
+            event: The event triggered when the ingress relation is removed.
+        """
+        logger.info("Ingress relation removed; Airbyte is no longer exposed via ingress")
 
     @log_event_handler(logger)
     def _on_peer_relation_changed(self, event):
@@ -370,6 +395,9 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             WORKLOAD_API_PORT,
             WORKLOAD_LAUNCHER_PORT,
         )
+
+        if not self.ingress.url:
+            logger.info("Ingress relation not configured; Airbyte is not exposed via ingress")
 
         flags_yaml_content = self._generate_flags_yaml_content()
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -41,7 +41,9 @@ class TestDeployment:
         """
         await ops_test.model.deploy(TRAEFIK_NAME, channel="latest/stable", trust=True)
         await ops_test.model.integrate(f"{APP_NAME_AIRBYTE_SERVER}:ingress", f"{TRAEFIK_NAME}:ingress")
-        await ops_test.model.wait_for_idle(apps=[TRAEFIK_NAME], status="active", raise_on_blocked=False, timeout=600)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME_AIRBYTE_SERVER, TRAEFIK_NAME], status="active", raise_on_blocked=False, timeout=600
+        )
 
         action = await ops_test.model.applications[TRAEFIK_NAME].units[0].run_action("show-proxied-endpoints")
         result = await action.wait()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
 
 import pytest
@@ -11,8 +12,7 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-INGRESS_INTEGRATOR_NAME = "nginx-ingress-integrator"
-INGRESS_HOSTNAME = "airbyte.test"
+TRAEFIK_NAME = "traefik-k8s"
 
 
 @pytest.mark.abort_on_fail
@@ -33,17 +33,17 @@ class TestDeployment:
         await run_test_sync_job(ops_test)
 
     async def test_ingress(self, ops_test: OpsTest):
-        """Airbyte exposes itself over the standard ingress interface.
+        """Airbyte exposes itself over the standard ingress interface via Traefik.
 
-        Deploys an ingress provider, integrates over the `ingress` relation, and
-        verifies the provider creates a route from the relation data the charm publishes.
+        FE uses Traefik for customer deployments, so this verifies
+        the charm's ingress relation works with it: integrate over `ingress`, then
+        confirm Traefik publishes a proxied URL for the Airbyte app.
         """
-        await ops_test.model.deploy(INGRESS_INTEGRATOR_NAME, channel="latest/stable", trust=True)
-        await ops_test.model.applications[INGRESS_INTEGRATOR_NAME].set_config({"service-hostname": INGRESS_HOSTNAME})
-        await ops_test.model.integrate(f"{APP_NAME_AIRBYTE_SERVER}:ingress", f"{INGRESS_INTEGRATOR_NAME}:ingress")
-        await ops_test.model.wait_for_idle(
-            apps=[INGRESS_INTEGRATOR_NAME], status="active", raise_on_blocked=False, timeout=600
-        )
+        await ops_test.model.deploy(TRAEFIK_NAME, channel="latest/stable", trust=True)
+        await ops_test.model.integrate(f"{APP_NAME_AIRBYTE_SERVER}:ingress", f"{TRAEFIK_NAME}:ingress")
+        await ops_test.model.wait_for_idle(apps=[TRAEFIK_NAME], status="active", raise_on_blocked=False, timeout=600)
 
-        unit = ops_test.model.applications[INGRESS_INTEGRATOR_NAME].units[0]
-        assert "Ingress IP" in unit.workload_status_message
+        action = await ops_test.model.applications[TRAEFIK_NAME].units[0].run_action("show-proxied-endpoints")
+        result = await action.wait()
+        proxied_endpoints = json.loads(result.results["proxied-endpoints"])
+        assert APP_NAME_AIRBYTE_SERVER in proxied_endpoints

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,6 +11,9 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+INGRESS_INTEGRATOR_NAME = "nginx-ingress-integrator"
+INGRESS_HOSTNAME = "airbyte.test"
+
 
 @pytest.mark.abort_on_fail
 @pytest.mark.usefixtures("deploy")
@@ -28,3 +31,19 @@ class TestDeployment:
 
     async def test_sync_job(self, ops_test: OpsTest):
         await run_test_sync_job(ops_test)
+
+    async def test_ingress(self, ops_test: OpsTest):
+        """Airbyte exposes itself over the standard ingress interface.
+
+        Deploys an ingress provider, integrates over the `ingress` relation, and
+        verifies the provider creates a route from the relation data the charm publishes.
+        """
+        await ops_test.model.deploy(INGRESS_INTEGRATOR_NAME, channel="latest/stable", trust=True)
+        await ops_test.model.applications[INGRESS_INTEGRATOR_NAME].set_config({"service-hostname": INGRESS_HOSTNAME})
+        await ops_test.model.integrate(f"{APP_NAME_AIRBYTE_SERVER}:ingress", f"{INGRESS_INTEGRATOR_NAME}:ingress")
+        await ops_test.model.wait_for_idle(
+            apps=[INGRESS_INTEGRATOR_NAME], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        unit = ops_test.model.applications[INGRESS_INTEGRATOR_NAME].units[0]
+        assert "Ingress IP" in unit.workload_status_message

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer
 
 from charm import AirbyteK8SOperatorCharm
-from src.literals import BASE_ENV, CONTAINER_HEALTH_CHECK_MAP
+from src.literals import BASE_ENV, CONTAINER_HEALTH_CHECK_MAP, INTERNAL_API_PORT
 from src.structured_config import StorageType
 
 logging.basicConfig(level=logging.DEBUG)
@@ -323,6 +323,45 @@ class TestCharm(TestCase):
 
         self.assertEqual(json.loads(peer_data(out)["s3"]), S3_STATE)
         self.assertEqual(out.unit_status, MaintenanceStatus("replanning application"))
+
+    def test_ingress_advertises_port(self):
+        """The charm advertises its UI port to a related ingress provider."""
+        ingress = testing.Relation("ingress", remote_app_name="traefik")
+        state = add_relations(make_state(db=True, minio=True), ingress)
+        out = self.ctx.run(self.ctx.on.relation_changed(ingress), state)
+
+        published = json.dumps(dict(out.get_relation(ingress.id).local_app_data))
+        self.assertIn(str(INTERNAL_API_PORT), published)
+
+    def test_ingress_url_available(self):
+        """The charm reads the workload URL from the ingress relation data."""
+        ingress = testing.Relation(
+            "ingress",
+            remote_app_name="traefik",
+            remote_app_data={"ingress": json.dumps({"url": "http://airbyte.example.com/"})},
+        )
+        state = add_relations(make_state(db=True, minio=True), ingress)
+        with self.ctx(self.ctx.on.relation_changed(ingress), state) as manager:
+            manager.run()
+            self.assertEqual(manager.charm.ingress.url, "http://airbyte.example.com/")
+
+    def test_ingress_revoked(self):
+        """The charm handles the ingress relation being removed without error."""
+        ingress = testing.Relation(
+            "ingress",
+            remote_app_name="traefik",
+            remote_app_data={"ingress": json.dumps({"url": "http://airbyte.example.com/"})},
+        )
+        state = add_relations(make_state(db=True, minio=True), ingress)
+        out = self.ctx.run(self.ctx.on.relation_broken(ingress), state)
+        self.assertNotIsInstance(out.unit_status, BlockedStatus)
+
+    def test_no_ingress_relation_does_not_error(self):
+        """Without an ingress relation the charm reconciles with no ingress URL and no error."""
+        state = make_state(db=True, minio=True)
+        with self.ctx(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state) as manager:
+            manager.run()
+            self.assertIsNone(manager.charm.ingress.url)
 
 
 def _up_check(status):


### PR DESCRIPTION
Adds the standard ingress interface to the Airbyte charm, so it can be exposed through any compatible provider (NGINX Ingress Integrator, Traefik, etc.).

### Changes

- `charmcraft.yaml`: new optional ingress require endpoint (interface: ingress, limit: 1).
- `lib/charms/traefik_k8s/v2/ingress.py`: vendored the standard requirer library.
- `src/charm.py`: wire up `IngressPerAppRequirer` on port 8001 with `strip_prefix=True`; observe ready/revoked and log the exposed URL/removal.
- Docs: reworded the how-to to integrate over the provider-agnostic ingress interface; minor wording in index/architecture.
- Tests: integration test against `traefik-k8s` (FE uses Traefik in customer deployments) + unit coverage.
- `rockcraft.yaml` (CI fix): point the in-build Docker daemon's registry-mirrors at Canonical's internal Docker Hub cache so Testcontainers' `postgres:15-alpine` pull stops tripping the shared runners' anonymous rate limit.

> ...
[](https://github.com/canonical/airbyte-k8s-operator/actions/runs/27942411364/job/82684846498#step:13:4381)2026-06-22 10:34:51.658 :: \[docker-java-stream--131774002\] ERROR com.github.dockerjava.api.async.ResultCallbackTemplate - Error during callback
[](https://github.com/canonical/airbyte-k8s-operator/actions/runs/27942411364/job/82684846498#step:13:4382)2026-06-22 10:34:51.658 :: com.github.dockerjava.api.exception.InternalServerErrorException: Status 500: {"message":"error from registry: You have reached your unauthenticated pull rate limit. [https://www.docker.com/increase-rate-limit](https://www.docker.com/increase-rate-limit)"}
...
[](https://github.com/canonical/airbyte-k8s-operator/actions/runs/27942411364/job/82684846498#step:13:4387)2026-06-22 10:34:51.658 :: \[main\] WARN tc.postgres:15-alpine - Retrying pull for image: postgres:15-alpine (106s remaining)
...

### Testing                            
Validated end-to-end on microk8s + `nginx-ingress-integrator` (Multipass): relation establishes over ingress, routes to `:8001`, charm surfaces the URL on ready, and removal is handled gracefully. CI exercises the same flow against `traefik-k8s`.