### PR TITLE
ci: fix charm publish permissions

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -9,5 +9,7 @@ jobs:
   test-and-publish-charm:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
+    permissions:
+      contents: write
     with:
       channel: latest/edge


### PR DESCRIPTION
Adds `contents:write` permissions to the charm publish job which currently 403s with `Resource not accessible by integration`.