### PR TITLE
fix: dataplane auth secret deadlock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "serialized-data-interface == 0.7.0",
     "charmed-kubeflow-chisme == 0.3.0",
     "kubernetes == 24.2.0",
+    "pg8000 ~= 1.31",
     "jinja2 ~= 3.1",
     "cosl >= 0.0.50",
     "charmlibs-interfaces-otlp >= 0.5.0",

--- a/src/charm.py
+++ b/src/charm.py
@@ -493,8 +493,8 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         # and runtime services crash, so configure only the bootloader and wait for it to appear.
         auth_secret = self._read_auth_secret()
 
-        # Dataplane credentials are only written on first dataplane creation (empty database), so
-        # they are injected when present & never blocked on them (a redeploy reuses an existing one).
+        # Dataplane credentials are only written on first dataplane creation (empty database);
+        # inject them when present but never block on them (a redeploy reuses an existing one).
         dataplane_env = {}
         if auth_secret:
             if auth_secret.get("dataplane-client-id"):

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,8 @@ import logging
 
 import kubernetes.client
 import ops
+import pg8000.exceptions
+import pg8000.native
 from botocore.exceptions import ClientError
 from charmlibs.interfaces.otlp import OtlpRequirer
 from charms.data_platform_libs.v0.data_models import TypedCharmBase
@@ -43,6 +45,10 @@ from s3_helpers import S3Client
 from structured_config import CharmConfig, StorageType
 
 logger = logging.getLogger(__name__)
+
+
+class DataplaneCredentialsError(Exception):
+    """Raised when dataplane credentials cannot be read from the Airbyte database."""
 
 
 def get_pebble_layer(application_name, context):
@@ -442,6 +448,130 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return {k: base64.b64decode(v).decode("utf-8") for k, v in (secret.data or {}).items()}
 
+    def _ensure_dataplane_credentials(self, auth_secret, db_connection):
+        """Backfill dataplane credentials into airbyte-auth-secrets from the database.
+
+        The bootloader writes them only on first creation, so on a reused database recover
+        them from the database and patch the secret.
+
+        Args:
+            auth_secret: the decoded airbyte-auth-secrets data.
+            db_connection: the database connection details from the db relation.
+
+        Returns:
+            The auth_secret data, with dataplane credentials filled in when recovered.
+        """
+        if auth_secret.get("dataplane-client-id") and auth_secret.get("dataplane-client-secret"):
+            return auth_secret
+
+        credentials = self._fetch_dataplane_credentials(db_connection)
+        if credentials is None:
+            logger.warning("No dataplane row in the database; cannot backfill airbyte-auth-secrets")
+            return auth_secret
+
+        client_id, client_secret = credentials
+        dataplane_credentials = {"dataplane-client-id": client_id, "dataplane-client-secret": client_secret}
+        if self._patch_auth_secret(dataplane_credentials):
+            logger.info("Backfilled dataplane credentials into airbyte-auth-secrets from the database")
+        return {**auth_secret, **dataplane_credentials}
+
+    def _fetch_dataplane_credentials(self, db_connection):
+        """Read the dataplane client credentials from the Airbyte database.
+
+        Args:
+            db_connection: the database connection details from the db relation.
+
+        Raises:
+            DataplaneCredentialsError: when the relation carries no credentials, or the
+                database cannot be reached or queried.
+
+        Returns:
+            A (client_id, client_secret) tuple, or None when no dataplane row exists yet.
+        """
+        if not db_connection.user or not db_connection.password:
+            raise DataplaneCredentialsError("db relation provided no username/password")
+
+        try:
+            connection = pg8000.native.Connection(
+                user=db_connection.user,
+                password=db_connection.password,
+                host=db_connection.host,
+                port=int(db_connection.port),
+                database=db_connection.dbname,
+            )
+            try:
+                rows = connection.run(
+                    "SELECT c.client_id, c.client_secret "
+                    "FROM dataplane_client_credentials c "
+                    "JOIN dataplane d ON d.id = c.dataplane_id "
+                    "WHERE d.enabled AND NOT d.tombstone "
+                    "ORDER BY c.created_at DESC LIMIT 1"
+                )
+            finally:
+                connection.close()
+        except (pg8000.exceptions.Error, OSError) as err:
+            raise DataplaneCredentialsError(f"database query failed: {err}") from err
+
+        if not rows:
+            return None
+
+        client_id, client_secret = rows[0]
+        return str(client_id), str(client_secret)
+
+    def _patch_auth_secret(self, data):
+        """Patch decoded key/value pairs into the airbyte-auth-secrets K8s secret.
+
+        Args:
+            data: a str->str mapping of keys to add or update in the secret.
+
+        Returns:
+            True when the secret was patched, False when the API rejected the patch.
+        """
+        encoded = {key: base64.b64encode(value.encode("utf-8")).decode("utf-8") for key, value in data.items()}
+        try:
+            self._k8s_client.patch_namespaced_secret(AIRBYTE_AUTH_K8S_SECRET_NAME, self.model.name, {"data": encoded})
+        except ApiException as err:
+            logger.error("Error patching secret %r: %s", AIRBYTE_AUTH_K8S_SECRET_NAME, str(err))
+            return False
+        return True
+
+    def _resolve_dataplane_env(self, auth_secret, db_connection):
+        """Resolve dataplane env vars and the runtime gate status from the auth secret.
+
+        Args:
+            auth_secret: the decoded airbyte-auth-secrets data, or None when not yet created.
+            db_connection: the database connection details from the db relation.
+
+        Returns:
+            A (dataplane_env, runtime_status) tuple: the credentials to inject, and the status
+            explaining why runtime services must wait, or None when they are ready to start.
+        """
+        dataplane_error = False
+        if auth_secret is not None:
+            try:
+                auth_secret = self._ensure_dataplane_credentials(auth_secret, db_connection)
+            except DataplaneCredentialsError as err:
+                logger.warning("Could not recover dataplane credentials: %s", err)
+                dataplane_error = True
+
+        dataplane_env = {}
+        if auth_secret:
+            if auth_secret.get("dataplane-client-id"):
+                dataplane_env["DATAPLANE_CLIENT_ID"] = auth_secret["dataplane-client-id"]
+            if auth_secret.get("dataplane-client-secret"):
+                dataplane_env["DATAPLANE_CLIENT_SECRET"] = auth_secret["dataplane-client-secret"]
+
+        if auth_secret is None:
+            return dataplane_env, WaitingStatus("waiting for airbyte-auth-secrets")
+
+        if dataplane_error:
+            return dataplane_env, WaitingStatus("error recovering dataplane credentials from database")
+
+        if not dataplane_env.get("DATAPLANE_CLIENT_ID") or not dataplane_env.get("DATAPLANE_CLIENT_SECRET"):
+            return dataplane_env, BlockedStatus("dataplane credentials not found in database")
+
+        return dataplane_env, None
+
     def reconcile(self):  # noqa: C901
         """Reconcile the charm to its desired state.
 
@@ -489,18 +619,9 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if not self.ingress.url:
             logger.info("Ingress relation not configured; Airbyte is not exposed via ingress")
 
-        # Until the bootloader creates airbyte-auth-secrets, the auth subsystem is uninitialised
-        # and runtime services crash, so configure only the bootloader and wait for it to appear.
+        # Runtime services need airbyte-auth-secrets and its dataplane credentials
         auth_secret = self._read_auth_secret()
-
-        # Dataplane credentials are only written on first dataplane creation (empty database);
-        # inject them when present but never block on them (a redeploy reuses an existing one).
-        dataplane_env = {}
-        if auth_secret:
-            if auth_secret.get("dataplane-client-id"):
-                dataplane_env["DATAPLANE_CLIENT_ID"] = auth_secret["dataplane-client-id"]
-            if auth_secret.get("dataplane-client-secret"):
-                dataplane_env["DATAPLANE_CLIENT_SECRET"] = auth_secret["dataplane-client-secret"]
+        dataplane_env, runtime_status = self._resolve_dataplane_env(auth_secret, db_connection)
 
         otel_collector_endpoint = self._get_otel_metrics_endpoint()
 
@@ -509,7 +630,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             if not container.can_connect():
                 continue
 
-            if auth_secret is None and container_name != "airbyte-bootloader":
+            if runtime_status is not None and container_name != "airbyte-bootloader":
                 continue
 
             env = create_env(
@@ -530,8 +651,8 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             container.add_layer(container_name, pebble_layer, combine=True)
             container.replan()
 
-        if auth_secret is None:
-            self.unit.status = WaitingStatus("waiting for airbyte-auth-secrets")
+        if runtime_status is not None:
+            self.unit.status = runtime_status
             return
 
         self.unit.status = MaintenanceStatus("replanning application")

--- a/src/charm.py
+++ b/src/charm.py
@@ -365,13 +365,12 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return content
 
-    def _get_auth_secret_env(self):
-        """Return the dataplane env vars from the bootloader-created K8s secret.
+    def _read_auth_secret(self) -> dict | None:
+        """Return the decoded airbyte-auth-secrets data, or None if not yet created.
 
         Returns:
-            A mapping with DATAPLANE_CLIENT_ID/DATAPLANE_CLIENT_SECRET when the
-            airbyte-auth-secrets secret exists and is populated, or an empty dict
-            if it has not been created yet (the bootloader creates it on startup).
+            The decoded secret data as a str->str mapping, or None when the secret
+            does not exist yet (the bootloader has not created it).
         """
         try:
             secret = self._k8s_client.read_namespaced_secret(AIRBYTE_AUTH_K8S_SECRET_NAME, self.model.name)
@@ -380,15 +379,9 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 logger.info("Secret %r not yet created in namespace %r", AIRBYTE_AUTH_K8S_SECRET_NAME, self.model.name)
             else:
                 logger.error("Error reading secret %r: %s", AIRBYTE_AUTH_K8S_SECRET_NAME, str(err))
-            return {}
+            return None
 
-        decoded = {k: base64.b64decode(v).decode("utf-8") for k, v in (secret.data or {}).items()}
-        env = {}
-        if decoded.get("dataplane-client-id"):
-            env["DATAPLANE_CLIENT_ID"] = decoded["dataplane-client-id"]
-        if decoded.get("dataplane-client-secret"):
-            env["DATAPLANE_CLIENT_SECRET"] = decoded["dataplane-client-secret"]
-        return env
+        return {k: base64.b64decode(v).decode("utf-8") for k, v in (secret.data or {}).items()}
 
     def reconcile(self):  # noqa: C901
         """Reconcile the charm to its desired state.
@@ -437,17 +430,25 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if not self.ingress.url:
             logger.info("Ingress relation not configured; Airbyte is not exposed via ingress")
 
-        # Runtime services crash without DATAPLANE_CLIENT_ID/SECRET, so until the secret exists
-        # configure only the bootloader and leave the rest unconfigured; update-status then
-        # re-reconciles once it appears.
-        dataplane_env = self._get_auth_secret_env()
+        # Until the bootloader creates airbyte-auth-secrets, the auth subsystem is uninitialised
+        # and runtime services crash, so configure only the bootloader and wait for it to appear.
+        auth_secret = self._read_auth_secret()
+
+        # Dataplane credentials are only written on first dataplane creation (empty database), so
+        # they are injected when present & never blocked on them (a redeploy reuses an existing one).
+        dataplane_env = {}
+        if auth_secret:
+            if auth_secret.get("dataplane-client-id"):
+                dataplane_env["DATAPLANE_CLIENT_ID"] = auth_secret["dataplane-client-id"]
+            if auth_secret.get("dataplane-client-secret"):
+                dataplane_env["DATAPLANE_CLIENT_SECRET"] = auth_secret["dataplane-client-secret"]
 
         for container_name in CONTAINER_HEALTH_CHECK_MAP:
             container = self.unit.get_container(container_name)
             if not container.can_connect():
                 continue
 
-            if not dataplane_env and container_name != "airbyte-bootloader":
+            if auth_secret is None and container_name != "airbyte-bootloader":
                 continue
 
             env = create_env(
@@ -467,7 +468,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             container.add_layer(container_name, pebble_layer, combine=True)
             container.replan()
 
-        if not dataplane_env:
+        if auth_secret is None:
             self.unit.status = WaitingStatus("waiting for airbyte-auth-secrets")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -424,13 +424,12 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
 
         return content
 
-    def _get_auth_secret_env(self):
-        """Return the dataplane env vars from the bootloader-created K8s secret.
+    def _read_auth_secret(self) -> dict | None:
+        """Return the decoded airbyte-auth-secrets data, or None if not yet created.
 
         Returns:
-            A mapping with DATAPLANE_CLIENT_ID/DATAPLANE_CLIENT_SECRET when the
-            airbyte-auth-secrets secret exists and is populated, or an empty dict
-            if it has not been created yet (the bootloader creates it on startup).
+            The decoded secret data as a str->str mapping, or None when the secret
+            does not exist yet (the bootloader has not created it).
         """
         try:
             secret = self._k8s_client.read_namespaced_secret(AIRBYTE_AUTH_K8S_SECRET_NAME, self.model.name)
@@ -439,15 +438,9 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
                 logger.info("Secret %r not yet created in namespace %r", AIRBYTE_AUTH_K8S_SECRET_NAME, self.model.name)
             else:
                 logger.error("Error reading secret %r: %s", AIRBYTE_AUTH_K8S_SECRET_NAME, str(err))
-            return {}
+            return None
 
-        decoded = {k: base64.b64decode(v).decode("utf-8") for k, v in (secret.data or {}).items()}
-        env = {}
-        if decoded.get("dataplane-client-id"):
-            env["DATAPLANE_CLIENT_ID"] = decoded["dataplane-client-id"]
-        if decoded.get("dataplane-client-secret"):
-            env["DATAPLANE_CLIENT_SECRET"] = decoded["dataplane-client-secret"]
-        return env
+        return {k: base64.b64decode(v).decode("utf-8") for k, v in (secret.data or {}).items()}
 
     def reconcile(self):  # noqa: C901
         """Reconcile the charm to its desired state.
@@ -496,10 +489,18 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         if not self.ingress.url:
             logger.info("Ingress relation not configured; Airbyte is not exposed via ingress")
 
-        # Runtime services crash without DATAPLANE_CLIENT_ID/SECRET, so until the secret exists
-        # configure only the bootloader and leave the rest unconfigured; update-status then
-        # re-reconciles once it appears.
-        dataplane_env = self._get_auth_secret_env()
+        # Until the bootloader creates airbyte-auth-secrets, the auth subsystem is uninitialised
+        # and runtime services crash, so configure only the bootloader and wait for it to appear.
+        auth_secret = self._read_auth_secret()
+
+        # Dataplane credentials are only written on first dataplane creation (empty database), so
+        # they are injected when present & never blocked on them (a redeploy reuses an existing one).
+        dataplane_env = {}
+        if auth_secret:
+            if auth_secret.get("dataplane-client-id"):
+                dataplane_env["DATAPLANE_CLIENT_ID"] = auth_secret["dataplane-client-id"]
+            if auth_secret.get("dataplane-client-secret"):
+                dataplane_env["DATAPLANE_CLIENT_SECRET"] = auth_secret["dataplane-client-secret"]
 
         otel_collector_endpoint = self._get_otel_metrics_endpoint()
 
@@ -508,7 +509,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             if not container.can_connect():
                 continue
 
-            if not dataplane_env and container_name != "airbyte-bootloader":
+            if auth_secret is None and container_name != "airbyte-bootloader":
                 continue
 
             env = create_env(
@@ -529,7 +530,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             container.add_layer(container_name, pebble_layer, combine=True)
             container.replan()
 
-        if not dataplane_env:
+        if auth_secret is None:
             self.unit.status = WaitingStatus("waiting for airbyte-auth-secrets")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -434,8 +434,8 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
         # and runtime services crash, so configure only the bootloader and wait for it to appear.
         auth_secret = self._read_auth_secret()
 
-        # Dataplane credentials are only written on first dataplane creation (empty database), so
-        # they are injected when present & never blocked on them (a redeploy reuses an existing one).
+        # Dataplane credentials are only written on first dataplane creation (empty database);
+        # inject them when present but never block on them (a redeploy reuses an existing one).
         dataplane_env = {}
         if auth_secret:
             if auth_secret.get("dataplane-client-id"):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,6 +74,15 @@ class TestCharm(TestCase):
         }
         self.mock_core_v1_instance.read_namespaced_secret.return_value = fake_secret
 
+        # Stub the Postgres driver so the dataplane-credential backfill never opens a real
+        # connection; defaults to no dataplane row.
+        patcher3 = patch("pg8000.native.Connection")
+        self.mock_pg_connection_cls = patcher3.start()
+        self.addCleanup(patcher3.stop)
+        self.mock_pg_connection = MagicMock()
+        self.mock_pg_connection_cls.return_value = self.mock_pg_connection
+        self.mock_pg_connection.run.return_value = []
+
         # The S3/MinIO client only performs bucket operations during reconcile;
         # stubbed out so no object storage is contacted.
         for target in (
@@ -337,18 +346,53 @@ class TestCharm(TestCase):
         plan = out.get_container("airbyte-server").plan.to_dict()
         self.assertNotIn("airbyte-server", plan.get("services", {}))
 
-    def test_auth_secret_without_dataplane_keys_configures_runtime(self):
-        """A redeploy reusing an existing dataplane configures runtime without dataplane env."""
+    def test_reused_db_backfills_dataplane_credentials(self):
+        """A redeploy against a reused database backfills dataplane creds from the database.
+
+        The bootloader recreates airbyte-auth-secrets without dataplane keys; the charm
+        recovers them from the database, injects them into the plan, and patches the secret.
+        """
         secret = MagicMock()
         secret.data = {"instance-admin-client-id": base64.b64encode(b"admin-id")}
         self.mock_core_v1_instance.read_namespaced_secret.return_value = secret
+        self.mock_pg_connection.run.return_value = [["db-client-id", "db-client-secret"]]
+
         state = make_state(db=True, minio=True)
         out = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
 
         self.assertNotIsInstance(out.unit_status, WaitingStatus)
         env = out.get_container("airbyte-server").plan.to_dict()["services"]["airbyte-server"]["environment"]
-        self.assertNotIn("DATAPLANE_CLIENT_ID", env)
-        self.assertNotIn("DATAPLANE_CLIENT_SECRET", env)
+        self.assertEqual(env["DATAPLANE_CLIENT_ID"], "db-client-id")
+        self.assertEqual(env["DATAPLANE_CLIENT_SECRET"], "db-client-secret")
+        self.mock_core_v1_instance.patch_namespaced_secret.assert_called_once()
+
+    def test_reused_db_no_dataplane_row_blocks(self):
+        """No dataplane row to recover blocks with a clear message and no runtime plan."""
+        secret = MagicMock()
+        secret.data = {"instance-admin-client-id": base64.b64encode(b"admin-id")}
+        self.mock_core_v1_instance.read_namespaced_secret.return_value = secret
+        self.mock_pg_connection.run.return_value = []  # no dataplane row exists
+
+        state = make_state(db=True, minio=True)
+        out = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
+
+        self.assertEqual(out.unit_status, BlockedStatus("dataplane credentials not found in database"))
+        plan = out.get_container("airbyte-server").plan.to_dict()
+        self.assertNotIn("airbyte-server", plan.get("services", {}))
+
+    def test_dataplane_credentials_db_error_waits(self):
+        """A database error while recovering dataplane creds surfaces a distinct waiting status."""
+        secret = MagicMock()
+        secret.data = {"instance-admin-client-id": base64.b64encode(b"admin-id")}
+        self.mock_core_v1_instance.read_namespaced_secret.return_value = secret
+        self.mock_pg_connection.run.side_effect = OSError("connection refused")
+
+        state = make_state(db=True, minio=True)
+        out = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
+
+        self.assertEqual(out.unit_status, WaitingStatus("error recovering dataplane credentials from database"))
+        plan = out.get_container("airbyte-server").plan.to_dict()
+        self.assertNotIn("airbyte-server", plan.get("services", {}))
 
 
 def _up_check(status):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -337,6 +337,19 @@ class TestCharm(TestCase):
         plan = out.get_container("airbyte-server").plan.to_dict()
         self.assertNotIn("airbyte-server", plan.get("services", {}))
 
+    def test_auth_secret_without_dataplane_keys_configures_runtime(self):
+        """A redeploy reusing an existing dataplane configures runtime without dataplane env."""
+        secret = MagicMock()
+        secret.data = {"instance-admin-client-id": base64.b64encode(b"admin-id")}
+        self.mock_core_v1_instance.read_namespaced_secret.return_value = secret
+        state = make_state(db=True, minio=True)
+        out = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
+
+        self.assertNotIsInstance(out.unit_status, WaitingStatus)
+        env = out.get_container("airbyte-server").plan.to_dict()["services"]["airbyte-server"]["environment"]
+        self.assertNotIn("DATAPLANE_CLIENT_ID", env)
+        self.assertNotIn("DATAPLANE_CLIENT_SECRET", env)
+
 
 def _up_check(status):
     """Build the "up" CheckInfo mirroring the charm's pebble check definition.

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "kubernetes" },
     { name = "ops" },
+    { name = "pg8000" },
     { name = "pydantic" },
     { name = "serialized-data-interface" },
 ]
@@ -72,6 +73,7 @@ requires-dist = [
     { name = "jinja2", specifier = "~=3.1" },
     { name = "kubernetes", specifier = "==24.2.0" },
     { name = "ops", specifier = "~=3.7" },
+    { name = "pg8000", specifier = "~=1.31" },
     { name = "pydantic", specifier = "~=2.13" },
     { name = "serialized-data-interface", specifier = "==0.7.0" },
 ]
@@ -134,6 +136,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
 ]
 
 [[package]]
@@ -1415,6 +1426,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pg8000"
+version = "1.31.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "scramp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/9a/077ab21e700051e03d8c5232b6bcb9a1a4d4b6242c9a0226df2cfa306414/pg8000-1.31.5.tar.gz", hash = "sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78", size = 118933, upload-time = "2025-09-14T09:16:49.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/07/5fd183858dff4d24840f07fc845f213cd371a19958558607ba22035dadd7/pg8000-1.31.5-py3-none-any.whl", hash = "sha256:0af2c1926b153307639868d2ee5cef6cd3a7d07448e12736989b10e1d491e201", size = 57816, upload-time = "2025-09-14T09:16:47.798Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1836,6 +1860,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287, upload-time = "2024-11-20T21:06:05.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175, upload-time = "2024-11-20T21:06:03.961Z" },
+]
+
+[[package]]
+name = "scramp"
+version = "1.4.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/0c/a7a7f217b83cb7439abe2189e0a65b648a81f1b72d6cd2a80161b74c1bae/scramp-1.4.12.tar.gz", hash = "sha256:94b38decf26005b835050d06541a5aefb9914497f4de789c6d82a0abc4b934de", size = 19179, upload-time = "2026-07-05T10:30:54.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/9c/23bbbe3202c61e5b03708967014c51ea69972ddfbcd73fa2c5c0211f16a7/scramp-1.4.12-py3-none-any.whl", hash = "sha256:6adb2828c5d64bd7785a6878eed30f66ce0fae60bf5fc07c26ce1f521db3ec3e", size = 14361, upload-time = "2026-07-05T10:30:53.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

On a redeploy against a database that already has a registered Airbyte dataplane, the charm deadlocked at `waiting for airbyte-auth-secrets`. The bootloader only writes the `dataplane-client-id`/`-secret` keys when it first creates a dataplane (empty database); on a reused database it skips creation, so the gate never cleared. And the workload services hard-require `DATAPLANE_CLIENT_ID` at startup, so the real credentials must be supplied.

## Fix

The bootloader persists the dataplane credentials in the Airbyte database (`dataplane_client_credentials`), which survives redeploys. When `airbyte-auth-secrets` exists but lacks the dataplane keys, the charm recovers them from the database (scoped to the live dataplane) and patches them back into the secret. Adds `pg8000` for the query.

| Situation | `juju status` message | Log line |
|---|---|---|
| Auth secret not created yet | `WaitingStatus: waiting for airbyte-auth-secrets` | `info: Secret 'airbyte-auth-secrets' not yet created in namespace '<ns>'` |
| DB unreachable / query failed / relation has no creds | `WaitingStatus: error recovering dataplane credentials from database` | `warning: Could not recover dataplane credentials: <detail>` |
| DB reachable, no live dataplane row | `BlockedStatus: dataplane credentials not found in database` | `warning: No dataplane row in the database; cannot backfill airbyte-auth-secrets` |
| Backfill succeeded (secret lacked creds, now persisted) | proceeds from `MaintenanceStatus: replanning application` to `ActiveStatus` | `info: Backfilled dataplane credentials into airbyte-auth-secrets from the database` |
| Secret already carried dataplane creds | proceeds to `ActiveStatus` | _(no dataplane log line)_ |
| Secret patch failed (creds recovered, not persisted) | proceeds to `ActiveStatus` (creds injected this cycle, patch retried next reconcile) | `error: Error patching secret 'airbyte-auth-secrets': <detail>` (no "Backfilled…" line) |