### PR TITLE
feat: add Terraform modules

### DIFF
--- a/.github/workflows/test_terraform_modules.yaml
+++ b/.github/workflows/test_terraform_modules.yaml
@@ -1,0 +1,22 @@
+name: Terraform modules tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+jobs:
+  terraform-charm-tests:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
+    secrets: inherit
+    with:
+      k8s-controller: true
+      terraform-directories: '["terraform/charm"]'
+
+  terraform-product-tests:
+    uses: canonical/operator-workflows/.github/workflows/terraform_modules_test.yaml@main
+    secrets: inherit
+    with:
+      lxd-controller-with-k8s-cloud: true
+      terraform-directories: '["terraform/product"]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .venv/
 build/
+parts/
+stage/
+prime/
 *.charm
 .tox/
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -1,0 +1,47 @@
+# Airbyte K8s charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `airbyte-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the `airbyte-k8s`
+application only; its dependencies (PostgreSQL, Temporal, object storage, ingress,
+observability) are wired up by a higher-level product module.
+
+## Module structure
+
+- **main.tf** - Defines the `airbyte-k8s` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, resources, …).
+- **outputs.tf** - The application name and the `provides`/`requires` integration endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Using `airbyte-k8s` base module in higher level modules
+
+```text
+module "airbyte" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/charm"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+Create integrations, for instance against PostgreSQL:
+
+```text
+resource "juju_integration" "airbyte_db" {
+  model_uuid = var.model_uuid
+  application {
+    name     = module.airbyte.app_name
+    endpoint = module.airbyte.requires.db
+  }
+  application {
+    name     = "postgresql-k8s"
+    endpoint = "database"
+  }
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][airbyte-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[airbyte-integrations]: https://charmhub.io/airbyte-k8s/integrations

--- a/terraform/charm/main.tf
+++ b/terraform/charm/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "airbyte_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+  trust      = var.trust
+
+  charm {
+    name     = "airbyte-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = { for k, v in var.config : k => v if v != null }
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/terraform/charm/outputs.tf
+++ b/terraform/charm/outputs.tf
@@ -1,0 +1,27 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.airbyte_k8s.name
+}
+
+output "provides" {
+  description = "Map of the charm's `provides` integration endpoints."
+  value = {
+    airbyte_server    = "airbyte-server"
+    grafana_dashboard = "grafana-dashboard"
+  }
+}
+
+output "requires" {
+  description = "Map of the charm's `requires` integration endpoints."
+  value = {
+    db             = "db"
+    object_storage = "object-storage"
+    s3_parameters  = "s3-parameters"
+    ingress        = "ingress"
+    logging        = "logging"
+    send_otlp      = "send-otlp"
+  }
+}

--- a/terraform/charm/terraform.tf
+++ b/terraform/charm/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/charm/tests/main.tftest.hcl
+++ b/terraform/charm/tests/main.tftest.hcl
@@ -1,0 +1,30 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "basic_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    channel    = "latest/edge"
+  }
+
+  assert {
+    condition     = output.app_name == "airbyte-k8s"
+    error_message = "airbyte-k8s app_name did not match expected"
+  }
+
+  assert {
+    condition     = output.requires.db == "db"
+    error_message = "requires.db endpoint did not match expected"
+  }
+
+  assert {
+    condition     = output.requires.object_storage == "object-storage"
+    error_message = "requires.object_storage endpoint did not match expected"
+  }
+}

--- a/terraform/charm/tests/setup/main.tf
+++ b/terraform/charm/tests/setup/main.tf
@@ -1,0 +1,39 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      version = "~> 2.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "k8s_cloud_name" {
+  description = "Name of the Kubernetes cloud registered on the controller."
+  type        = string
+  default     = "tfk8s"
+}
+
+variable "k8s_credential_name" {
+  description = "Name of the credential for the Kubernetes cloud."
+  type        = string
+  default     = "tfk8s"
+}
+
+resource "juju_model" "test_model" {
+  name       = "tf-testing-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  credential = var.k8s_credential_name
+
+  cloud {
+    name = var.k8s_cloud_name
+  }
+}
+
+output "model_uuid" {
+  value = juju_model.test_model.uuid
+}

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -108,7 +108,7 @@ variable "revision" {
 }
 
 variable "trust" {
-  description = "Whether the application can access cluster-wide Kubernetes resources. Airbyte requires this to read and patch its auth secret."
+  description = "Whether the application can access cluster-wide Kubernetes resources. Airbyte requires this to read its auth secret via the Kubernetes API."
   type        = bool
   default     = true
 }

--- a/terraform/charm/variables.tf
+++ b/terraform/charm/variables.tf
@@ -1,0 +1,120 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "airbyte-k8s"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/airbyte-k8s/configurations."
+  type = object({
+    log-level                                                 = optional(string)
+    temporal-host                                             = optional(string)
+    webapp-url                                                = optional(string)
+    secret-persistence                                        = optional(string)
+    secret-store-gcp-project-id                               = optional(string)
+    gcp-credentials-secret-id                                 = optional(string)
+    vault-address                                             = optional(string)
+    vault-prefix                                              = optional(string)
+    vault-token-secret-id                                     = optional(string)
+    vault-auth-method                                         = optional(string)
+    aws-credentials-secret-id                                 = optional(string)
+    aws-kms-key-arn                                           = optional(string)
+    aws-secret-manager-secret-tags                            = optional(string)
+    sync-job-retries-complete-failures-max-successive         = optional(number)
+    sync-job-retries-complete-failures-max-total              = optional(number)
+    sync-job-retries-complete-failures-backoff-min-interval-s = optional(number)
+    sync-job-retries-complete-failures-backoff-max-interval-s = optional(number)
+    sync-job-retries-complete-failures-backoff-base           = optional(number)
+    sync-job-retries-partial-failures-max-successive          = optional(number)
+    sync-job-retries-partial-failures-max-total               = optional(number)
+    sync-job-max-timeout-days                                 = optional(number)
+    job-main-container-cpu-request                            = optional(string)
+    job-main-container-cpu-limit                              = optional(string)
+    job-main-container-memory-request                         = optional(string)
+    job-main-container-memory-limit                           = optional(string)
+    max-fields-per-connections                                = optional(number)
+    max-days-of-only-failed-jobs-before-connection-disable    = optional(number)
+    max-failed-jobs-in-a-row-before-connection-disable        = optional(number)
+    max-spec-workers                                          = optional(number)
+    max-check-workers                                         = optional(number)
+    max-sync-workers                                          = optional(number)
+    max-discover-workers                                      = optional(number)
+    temporal-history-retention-in-days                        = optional(number)
+    job-kube-tolerations                                      = optional(string)
+    job-kube-node-selectors                                   = optional(string)
+    job-kube-annotations                                      = optional(string)
+    job-kube-main-container-image-pull-policy                 = optional(string)
+    job-kube-main-container-image-pull-secret                 = optional(string)
+    job-kube-sidecar-container-image-pull-policy              = optional(string)
+    job-kube-socat-image                                      = optional(string)
+    job-kube-busybox-image                                    = optional(string)
+    job-kube-curl-image                                       = optional(string)
+    job-kube-namespace                                        = optional(string)
+    spec-job-kube-node-selectors                              = optional(string)
+    check-job-kube-node-selectors                             = optional(string)
+    discover-job-kube-node-selectors                          = optional(string)
+    spec-job-kube-annotations                                 = optional(string)
+    check-job-kube-annotations                                = optional(string)
+    discover-job-kube-annotations                             = optional(string)
+    storage-type                                              = optional(string)
+    storage-bucket-logs                                       = optional(string)
+    logs-ttl                                                  = optional(number)
+    storage-bucket-state                                      = optional(string)
+    storage-bucket-activity-payload                           = optional(string)
+    storage-bucket-workload-output                            = optional(string)
+    pod-running-ttl-minutes                                   = optional(number)
+    pod-successful-ttl-minutes                                = optional(number)
+    pod-unsuccessful-ttl-minutes                              = optional(number)
+  })
+  default = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to the `juju_model` UUID to deploy to."
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources (airbyte-image) to use instead of the charm's bundled image."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy. Null deploys the latest revision on the channel."
+  type        = number
+  default     = null
+}
+
+variable "trust" {
+  description = "Whether the application can access cluster-wide Kubernetes resources. Airbyte requires this to read and patch its auth secret."
+  type        = bool
+  default     = true
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/minio/README.md
+++ b/terraform/modules/minio/README.md
@@ -19,7 +19,7 @@ higher-level product module.
 | Name                 | Type          | Default          | Description                                              |
 | -------------------- | ------------- | ---------------- | -------------------------------------------------------- |
 | `app_name`           | `string`      | `"minio"`        | Name of the application in the Juju model.               |
-| `base`               | `string`      | `"ubuntu@22.04"` | The operating system on which to deploy.                 |
+| `base`               | `string`      | `"ubuntu@24.04"` | The operating system on which to deploy.                 |
 | `channel`            | `string`      | `"1.10/stable"`  | The channel to use when deploying the charm.             |
 | `config`             | `map(string)` | `{}`             | Application configuration.                               |
 | `constraints`        | `string`      | `null`           | Juju constraints to apply to the application.            |

--- a/terraform/modules/minio/README.md
+++ b/terraform/modules/minio/README.md
@@ -1,0 +1,54 @@
+# MinIO charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `minio` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the `minio`
+application only; integrations with consumers (e.g. Airbyte object storage) are wired up by a
+higher-level product module.
+
+## Module structure
+
+- **main.tf** - Defines the `minio` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, resources, …).
+- **outputs.tf** - The application name/resource and the `provides` integration endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Inputs
+
+| Name                 | Type          | Default          | Description                                              |
+| -------------------- | ------------- | ---------------- | -------------------------------------------------------- |
+| `app_name`           | `string`      | `"minio"`        | Name of the application in the Juju model.               |
+| `base`               | `string`      | `"ubuntu@22.04"` | The operating system on which to deploy.                 |
+| `channel`            | `string`      | `"1.10/stable"`  | The channel to use when deploying the charm.             |
+| `config`             | `map(string)` | `{}`             | Application configuration.                               |
+| `constraints`        | `string`      | `null`           | Juju constraints to apply to the application.            |
+| `model_uuid`         | `string`      | (required)       | UUID of the Juju model to deploy into.                   |
+| `resources`          | `map(string)` | `{}`             | OCI-image resources to use instead of the bundled ones.  |
+| `revision`           | `number`      | `null`           | Charm revision to deploy (`null` = latest on channel).   |
+| `storage_directives` | `map(string)` | `{}`             | Storage directives for the application.                  |
+| `units`              | `number`      | `1`              | Number of units to deploy.                               |
+
+## Outputs
+
+| Name          | Type          | Description                                            |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `app_name`    | `string`      | Name of the deployed application.                     |
+| `application` | `object`      | The deployed application resource.                    |
+| `provides`    | `map(string)` | Map of the charm's `provides` integration endpoints.  |
+
+## Using the `minio` base module in higher level modules
+
+```text
+module "minio" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/modules/minio"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][minio-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[minio-integrations]: https://charmhub.io/minio/integrations

--- a/terraform/modules/minio/main.tf
+++ b/terraform/modules/minio/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "minio" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "minio"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config             = var.config
+  constraints        = var.constraints
+  resources          = var.resources
+  storage_directives = var.storage_directives
+  units              = var.units
+}

--- a/terraform/modules/minio/outputs.tf
+++ b/terraform/modules/minio/outputs.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.minio.name
+}
+
+output "application" {
+  description = "The deployed application resource."
+  value       = juju_application.minio
+}
+
+output "provides" {
+  description = "Map of the charm's `provides` integration endpoints."
+  value = {
+    object_storage = "object-storage"
+  }
+}

--- a/terraform/modules/minio/terraform.tf
+++ b/terraform/modules/minio/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/modules/minio/variables.tf
+++ b/terraform/modules/minio/variables.tf
@@ -10,7 +10,7 @@ variable "app_name" {
 variable "base" {
   description = "The operating system on which to deploy."
   type        = string
-  default     = "ubuntu@22.04"
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {

--- a/terraform/modules/minio/variables.tf
+++ b/terraform/modules/minio/variables.tf
@@ -1,0 +1,62 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "minio"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "1.10/stable"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/minio/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply to the application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy into."
+  type        = string
+  nullable    = false
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources to use instead of the charm's bundled images."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Charm revision to deploy."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Storage directives for the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/postgresql-k8s/README.md
+++ b/terraform/modules/postgresql-k8s/README.md
@@ -1,0 +1,53 @@
+# PostgreSQL K8s charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `postgresql-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the `postgresql-k8s`
+application only; integrations with consumers are wired up by a higher-level product module.
+
+## Module structure
+
+- **main.tf** - Defines the `postgresql-k8s` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, resources, …).
+- **outputs.tf** - The application name/resource and the `provides` integration endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Inputs
+
+| Name                 | Type          | Default             | Description                                              |
+| -------------------- | ------------- | ------------------- | -------------------------------------------------------- |
+| `app_name`           | `string`      | `"postgresql-k8s"`  | Name of the application in the Juju model.               |
+| `base`               | `string`      | `"ubuntu@22.04"`    | The operating system on which to deploy.                 |
+| `channel`            | `string`      | `"14/stable"`       | The channel to use when deploying the charm.             |
+| `config`             | `map(string)` | `{}`                | Application configuration.                               |
+| `constraints`        | `string`      | `null`              | Juju constraints to apply to the application.            |
+| `model_uuid`         | `string`      | (required)          | UUID of the Juju model to deploy into.                   |
+| `resources`          | `map(string)` | `{}`                | OCI-image resources to use instead of the bundled ones.  |
+| `revision`           | `number`      | `null`              | Charm revision to deploy (`null` = latest on channel).   |
+| `storage_directives` | `map(string)` | `{}`                | Storage directives for the application.                  |
+| `units`              | `number`      | `1`                 | Number of units to deploy.                               |
+
+## Outputs
+
+| Name          | Type          | Description                                            |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `app_name`    | `string`      | Name of the deployed application.                     |
+| `application` | `object`      | The deployed application resource.                    |
+| `provides`    | `map(string)` | Map of the charm's `provides` integration endpoints.  |
+
+## Using the `postgresql-k8s` base module in higher level modules
+
+```text
+module "postgresql_k8s" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/modules/postgresql-k8s"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][postgresql-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[postgresql-integrations]: https://charmhub.io/postgresql-k8s/integrations

--- a/terraform/modules/postgresql-k8s/main.tf
+++ b/terraform/modules/postgresql-k8s/main.tf
@@ -1,0 +1,21 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "postgresql_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+  trust      = true
+
+  charm {
+    name     = "postgresql-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config             = var.config
+  constraints        = var.constraints
+  resources          = var.resources
+  storage_directives = var.storage_directives
+  units              = var.units
+}

--- a/terraform/modules/postgresql-k8s/outputs.tf
+++ b/terraform/modules/postgresql-k8s/outputs.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.postgresql_k8s.name
+}
+
+output "application" {
+  description = "The deployed application resource."
+  value       = juju_application.postgresql_k8s
+}
+
+output "provides" {
+  description = "Map of the charm's `provides` integration endpoints."
+  value = {
+    database = "database"
+  }
+}

--- a/terraform/modules/postgresql-k8s/terraform.tf
+++ b/terraform/modules/postgresql-k8s/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/modules/postgresql-k8s/variables.tf
+++ b/terraform/modules/postgresql-k8s/variables.tf
@@ -1,0 +1,62 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "postgresql-k8s"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "14/stable"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/postgresql-k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply to the application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy into."
+  type        = string
+  nullable    = false
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources to use instead of the charm's bundled images."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Charm revision to deploy."
+  type        = number
+  default     = null
+}
+
+variable "storage_directives" {
+  description = "Storage directives for the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/temporal-admin-k8s/README.md
+++ b/terraform/modules/temporal-admin-k8s/README.md
@@ -1,0 +1,53 @@
+# Temporal Admin K8s charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `temporal-admin-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the `temporal-admin-k8s`
+application only; its integration with `temporal-k8s` is wired up by a higher-level product
+module.
+
+## Module structure
+
+- **main.tf** - Defines the `temporal-admin-k8s` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, …).
+- **outputs.tf** - The application name/resource and the `provides` integration endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Inputs
+
+| Name          | Type          | Default                | Description                                            |
+| ------------- | ------------- | ---------------------- | ------------------------------------------------------ |
+| `app_name`    | `string`      | `"temporal-admin-k8s"` | Name of the application in the Juju model.             |
+| `base`        | `string`      | `"ubuntu@24.04"`       | The operating system on which to deploy.               |
+| `channel`     | `string`      | `"1.23/stable"`        | The channel to use when deploying the charm.           |
+| `config`      | `map(string)` | `{}`                   | Application configuration.                             |
+| `constraints` | `string`      | `null`                 | Juju constraints to apply to the application.          |
+| `model_uuid`  | `string`      | (required)             | UUID of the Juju model to deploy into.                 |
+| `resources`   | `map(string)` | `{}`                   | OCI-image resources to use instead of the bundled ones.|
+| `revision`    | `number`      | `null`                 | Charm revision to deploy (`null` = latest on channel). |
+| `units`       | `number`      | `1`                    | Number of units to deploy.                             |
+
+## Outputs
+
+| Name          | Type          | Description                                            |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `app_name`    | `string`      | Name of the deployed application.                     |
+| `application` | `object`      | The deployed application resource.                    |
+| `provides`    | `map(string)` | Map of the charm's `provides` integration endpoints.  |
+
+## Using the `temporal-admin-k8s` base module in higher level modules
+
+```text
+module "temporal_admin_k8s" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/modules/temporal-admin-k8s"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][temporal-admin-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[temporal-admin-integrations]: https://charmhub.io/temporal-admin-k8s/integrations

--- a/terraform/modules/temporal-admin-k8s/main.tf
+++ b/terraform/modules/temporal-admin-k8s/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "temporal_admin_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "temporal-admin-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/terraform/modules/temporal-admin-k8s/outputs.tf
+++ b/terraform/modules/temporal-admin-k8s/outputs.tf
@@ -1,0 +1,20 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.temporal_admin_k8s.name
+}
+
+output "application" {
+  description = "The deployed application resource."
+  value       = juju_application.temporal_admin_k8s
+}
+
+output "provides" {
+  description = "Map of the charm's `provides` integration endpoints."
+  value = {
+    admin              = "admin"
+    temporal_host_info = "temporal-host-info"
+  }
+}

--- a/terraform/modules/temporal-admin-k8s/terraform.tf
+++ b/terraform/modules/temporal-admin-k8s/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/modules/temporal-admin-k8s/variables.tf
+++ b/terraform/modules/temporal-admin-k8s/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "temporal-admin-k8s"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "1.23/stable"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/temporal-admin-k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply to the application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy into."
+  type        = string
+  nullable    = false
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources to use instead of the charm's bundled images."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Charm revision to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/temporal-k8s/README.md
+++ b/terraform/modules/temporal-k8s/README.md
@@ -1,0 +1,54 @@
+# Temporal K8s charm Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `temporal-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by Juju. It models the `temporal-k8s`
+application only; its dependencies (PostgreSQL, the admin charm) are wired up by a
+higher-level product module.
+
+## Module structure
+
+- **main.tf** - Defines the `temporal-k8s` Juju application.
+- **variables.tf** - Deployment options (model UUID, channel, revision, config, …).
+- **outputs.tf** - The application name/resource and the `provides`/`requires` endpoints.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Inputs
+
+| Name          | Type          | Default          | Description                                            |
+| ------------- | ------------- | ---------------- | ------------------------------------------------------ |
+| `app_name`    | `string`      | `"temporal-k8s"` | Name of the application in the Juju model.             |
+| `base`        | `string`      | `"ubuntu@24.04"` | The operating system on which to deploy.               |
+| `channel`     | `string`      | `"1.23/stable"`  | The channel to use when deploying the charm.           |
+| `config`      | `map(string)` | `{}`             | Application configuration.                             |
+| `constraints` | `string`      | `null`           | Juju constraints to apply to the application.          |
+| `model_uuid`  | `string`      | (required)       | UUID of the Juju model to deploy into.                 |
+| `resources`   | `map(string)` | `{}`             | OCI-image resources to use instead of the bundled ones.|
+| `revision`    | `number`      | `null`           | Charm revision to deploy (`null` = latest on channel). |
+| `units`       | `number`      | `1`              | Number of units to deploy.                             |
+
+## Outputs
+
+| Name          | Type          | Description                                            |
+| ------------- | ------------- | ----------------------------------------------------- |
+| `app_name`    | `string`      | Name of the deployed application.                     |
+| `application` | `object`      | The deployed application resource.                    |
+| `provides`    | `map(string)` | Map of the charm's `provides` integration endpoints.  |
+| `requires`    | `map(string)` | Map of the charm's `requires` integration endpoints.  |
+
+## Using the `temporal-k8s` base module in higher level modules
+
+```text
+module "temporal_k8s" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/modules/temporal-k8s"
+  model_uuid = var.model_uuid
+  # (Customize configuration variables here if needed)
+}
+```
+
+The complete list of available integrations can be found [in the Integrations tab][temporal-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[temporal-integrations]: https://charmhub.io/temporal-k8s/integrations

--- a/terraform/modules/temporal-k8s/main.tf
+++ b/terraform/modules/temporal-k8s/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "temporal_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "temporal-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/terraform/modules/temporal-k8s/outputs.tf
+++ b/terraform/modules/temporal-k8s/outputs.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.temporal_k8s.name
+}
+
+output "application" {
+  description = "The deployed application resource."
+  value       = juju_application.temporal_k8s
+}
+
+output "provides" {
+  description = "Map of the charm's `provides` integration endpoints."
+  value = {
+    temporal_host_info = "temporal-host-info"
+  }
+}
+
+output "requires" {
+  description = "Map of the charm's `requires` integration endpoints."
+  value = {
+    db         = "db"
+    visibility = "visibility"
+    admin      = "admin"
+  }
+}

--- a/terraform/modules/temporal-k8s/terraform.tf
+++ b/terraform/modules/temporal-k8s/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/modules/temporal-k8s/variables.tf
+++ b/terraform/modules/temporal-k8s/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "temporal-k8s"
+}
+
+variable "base" {
+  description = "The operating system on which to deploy."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying the charm."
+  type        = string
+  default     = "1.23/stable"
+}
+
+variable "config" {
+  description = "Application configuration. Options at https://charmhub.io/temporal-k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply to the application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy into."
+  type        = string
+  nullable    = false
+}
+
+variable "resources" {
+  description = "Map of OCI-image resources to use instead of the charm's bundled images."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Charm revision to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -1,0 +1,77 @@
+# Airbyte K8s product Terraform module
+
+This folder contains a product [Terraform][Terraform] module that deploys `airbyte-k8s`
+together with the dependencies it needs to run, and wires up the integrations between them.
+It composes the base [charm module](../charm) and is a **reference** for how the charm can be
+deployed — infrastructure-specific deployments (backends, ingress/TLS, SSO, external
+databases) are expected to build on top of it.
+
+## What it deploys
+
+Into a single Kubernetes Juju model (`model_uuid`):
+
+- **airbyte-k8s** — via the [charm module](../charm) (deployed with `trust`, which Airbyte
+  needs to read and patch its auth secret).
+- **postgresql-k8s** — the metadata database shared by Airbyte and Temporal.
+- **temporal-k8s** + **temporal-admin-k8s** — Airbyte's workflow engine and its schema manager.
+- **minio** — object storage for logs, state and workload output.
+
+## Integrations
+
+| From | To | Purpose |
+| --- | --- | --- |
+| `airbyte-k8s:db` | `postgresql-k8s:database` | Airbyte metadata database |
+| `airbyte-k8s:object-storage` | `minio:object-storage` | Airbyte object storage |
+| `temporal-k8s:db` | `postgresql-k8s:database` | Temporal default store |
+| `temporal-k8s:visibility` | `postgresql-k8s:database` | Temporal visibility store |
+| `temporal-k8s:admin` | `temporal-admin-k8s:admin` | Temporal schema management |
+| `temporal-k8s:temporal-host-info` | `temporal-admin-k8s:temporal-host-info` | Admin CLI addressing |
+
+Airbyte connects to Temporal through the `temporal-host` **config** (default
+`temporal-k8s:7233`), not a relation, so there is no Airbyte↔Temporal integration.
+
+## Module structure
+
+- **main.tf** - Composes the charm module, deploys the dependencies, and wires the integrations.
+- **variables.tf** - Per-application deployment options (channel, revision, base, config, units).
+- **outputs.tf** - The model UUID and the deployed application names.
+- **terraform.tf** - Terraform and provider version constraints.
+
+## Usage
+
+```text
+module "airbyte" {
+  source     = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/product"
+  model_uuid = var.model_uuid
+  # (Override per-application channels/revisions/config as needed)
+}
+```
+
+## External database
+
+By default the module deploys `postgresql-k8s` in-model and relates Airbyte and Temporal to it.
+To use an external database instead (e.g. a managed PostgreSQL on another controller), set
+`database_offer_url` to a consumable `database` offer URL — then `postgresql-k8s` is not deployed
+and the Airbyte and Temporal database relations point at the offer:
+
+```text
+module "airbyte" {
+  source             = "git::https://github.com/canonical/airbyte-k8s-operator//terraform/product"
+  model_uuid         = var.model_uuid
+  database_offer_url = "controller:admin/db-model.postgresql"
+}
+```
+
+## Notes
+
+- **Object storage:** this module uses MinIO. To use AWS S3 instead, drop the `minio`
+  application and its integration and relate `airbyte-k8s:s3-parameters` to an
+  `s3-integrator`, setting the charm's `storage-type` config to `S3`.
+- **Post-deploy step:** Temporal requires a default namespace, created via the
+  `temporal-admin-k8s` `cli` action (`tctl ... namespace register`). Terraform does not run
+  Juju actions, so run this once after `apply` for a fully functional stack.
+- **Observability / ingress:** the optional `logging`, `grafana-dashboard`, `send-otlp` and
+  `ingress` endpoints are left unwired here; relate them to COS and an ingress provider in a
+  higher-level module.
+
+[Terraform]: https://www.terraform.io/

--- a/terraform/product/locals.tf
+++ b/terraform/product/locals.tf
@@ -5,12 +5,25 @@ locals {
   # Deploy postgresql-k8s in-module unless an external database offer URL is supplied.
   deploy_database = var.database_offer_url == ""
 
+  configured_channels = {
+    airbyte        = var.airbyte.channel
+    postgresql     = var.postgresql.channel
+    temporal       = var.temporal.channel
+    temporal_admin = var.temporal_admin.channel
+    minio          = var.minio.channel
+  }
+
+  channels = {
+    for name, channel in local.configured_channels :
+    name => var.risk == null ? channel : "${length(split("/", channel)) > 1 ? split("/", channel)[0] : "latest"}/${var.risk}"
+  }
+
   # The PostgreSQL side of the database integrations: the in-module application endpoint when
   # deployed here, or the external offer URL otherwise. Consumed by the Airbyte and Temporal
   # database relations so both share one database backend.
   database_endpoint = {
-    name      = local.deploy_database ? one(juju_application.postgresql_k8s[*].name) : null
-    endpoint  = local.deploy_database ? "database" : null
+    name      = local.deploy_database ? one(module.postgresql_k8s[*].app_name) : null
+    endpoint  = local.deploy_database ? one(module.postgresql_k8s[*].provides["database"]) : null
     offer_url = local.deploy_database ? null : var.database_offer_url
   }
 }

--- a/terraform/product/locals.tf
+++ b/terraform/product/locals.tf
@@ -1,0 +1,16 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Deploy postgresql-k8s in-module unless an external database offer URL is supplied.
+  deploy_database = var.database_offer_url == ""
+
+  # The PostgreSQL side of the database integrations: the in-module application endpoint when
+  # deployed here, or the external offer URL otherwise. Consumed by the Airbyte and Temporal
+  # database relations so both share one database backend.
+  database_endpoint = {
+    name      = local.deploy_database ? one(juju_application.postgresql_k8s[*].name) : null
+    endpoint  = local.deploy_database ? "database" : null
+    offer_url = local.deploy_database ? null : var.database_offer_url
+  }
+}

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -1,0 +1,181 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+### AIRBYTE (via the base charm module)
+
+module "airbyte" {
+  source = "../charm"
+
+  app_name    = var.airbyte.app_name
+  model_uuid  = var.model_uuid
+  channel     = var.airbyte.channel
+  revision    = var.airbyte.revision
+  base        = var.airbyte.base
+  config      = var.airbyte.config
+  constraints = var.airbyte.constraints
+  resources   = var.airbyte.resources
+  trust       = var.airbyte.trust
+  units       = var.airbyte.units
+}
+
+### DEPENDENCIES
+
+resource "juju_application" "postgresql_k8s" {
+  count      = local.deploy_database ? 1 : 0
+  name       = var.postgresql.app_name
+  model_uuid = var.model_uuid
+  trust      = true
+
+  charm {
+    name     = "postgresql-k8s"
+    channel  = var.postgresql.channel
+    revision = var.postgresql.revision
+    base     = var.postgresql.base
+  }
+
+  config             = var.postgresql.config
+  constraints        = var.postgresql.constraints
+  storage_directives = var.postgresql.storage_directives
+  units              = var.postgresql.units
+}
+
+resource "juju_application" "temporal_k8s" {
+  name       = var.temporal.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "temporal-k8s"
+    channel  = var.temporal.channel
+    revision = var.temporal.revision
+    base     = var.temporal.base
+  }
+
+  config = var.temporal.config
+  units  = var.temporal.units
+}
+
+resource "juju_application" "temporal_admin_k8s" {
+  name       = var.temporal_admin.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "temporal-admin-k8s"
+    channel  = var.temporal_admin.channel
+    revision = var.temporal_admin.revision
+    base     = var.temporal_admin.base
+  }
+
+  units = var.temporal_admin.units
+}
+
+resource "juju_application" "minio" {
+  name       = var.minio.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "minio"
+    channel  = var.minio.channel
+    revision = var.minio.revision
+    base     = var.minio.base
+  }
+
+  config             = var.minio.config
+  storage_directives = var.minio.storage_directives
+  units              = var.minio.units
+}
+
+### INTEGRATIONS
+
+# Airbyte -> PostgreSQL (metadata database) and MinIO (object storage).
+resource "juju_integration" "airbyte_db" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.airbyte.app_name
+    endpoint = module.airbyte.requires.db
+  }
+  dynamic "application" {
+    for_each = [local.database_endpoint]
+    content {
+      name      = application.value.name
+      endpoint  = application.value.endpoint
+      offer_url = application.value.offer_url
+    }
+  }
+}
+
+resource "juju_integration" "airbyte_object_storage" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.airbyte.app_name
+    endpoint = module.airbyte.requires.object_storage
+  }
+  application {
+    name     = juju_application.minio.name
+    endpoint = "object-storage"
+  }
+}
+
+# Temporal -> PostgreSQL (default + visibility stores) and the admin charm.
+# Airbyte reaches Temporal via the `temporal-host` config (default `temporal-k8s:7233`),
+# not a relation, so no Airbyte<->Temporal integration is required here.
+resource "juju_integration" "temporal_db" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.temporal_k8s.name
+    endpoint = "db"
+  }
+  dynamic "application" {
+    for_each = [local.database_endpoint]
+    content {
+      name      = application.value.name
+      endpoint  = application.value.endpoint
+      offer_url = application.value.offer_url
+    }
+  }
+}
+
+resource "juju_integration" "temporal_visibility" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.temporal_k8s.name
+    endpoint = "visibility"
+  }
+  dynamic "application" {
+    for_each = [local.database_endpoint]
+    content {
+      name      = application.value.name
+      endpoint  = application.value.endpoint
+      offer_url = application.value.offer_url
+    }
+  }
+}
+
+resource "juju_integration" "temporal_admin" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.temporal_k8s.name
+    endpoint = "admin"
+  }
+  application {
+    name     = juju_application.temporal_admin_k8s.name
+    endpoint = "admin"
+  }
+}
+
+resource "juju_integration" "temporal_host_info" {
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.temporal_k8s.name
+    endpoint = "temporal-host-info"
+  }
+  application {
+    name     = juju_application.temporal_admin_k8s.name
+    endpoint = "temporal-host-info"
+  }
+}

--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -8,7 +8,7 @@ module "airbyte" {
 
   app_name    = var.airbyte.app_name
   model_uuid  = var.model_uuid
-  channel     = var.airbyte.channel
+  channel     = local.channels.airbyte
   revision    = var.airbyte.revision
   base        = var.airbyte.base
   config      = var.airbyte.config
@@ -20,66 +20,58 @@ module "airbyte" {
 
 ### DEPENDENCIES
 
-resource "juju_application" "postgresql_k8s" {
-  count      = local.deploy_database ? 1 : 0
-  name       = var.postgresql.app_name
-  model_uuid = var.model_uuid
-  trust      = true
+module "postgresql_k8s" {
+  count  = local.deploy_database ? 1 : 0
+  source = "../modules/postgresql-k8s"
 
-  charm {
-    name     = "postgresql-k8s"
-    channel  = var.postgresql.channel
-    revision = var.postgresql.revision
-    base     = var.postgresql.base
-  }
-
+  app_name           = var.postgresql.app_name
+  model_uuid         = var.model_uuid
+  channel            = local.channels.postgresql
+  revision           = var.postgresql.revision
+  base               = var.postgresql.base
   config             = var.postgresql.config
   constraints        = var.postgresql.constraints
+  resources          = var.postgresql.resources
   storage_directives = var.postgresql.storage_directives
   units              = var.postgresql.units
 }
 
-resource "juju_application" "temporal_k8s" {
-  name       = var.temporal.app_name
+module "temporal_k8s" {
+  source = "../modules/temporal-k8s"
+
+  app_name   = var.temporal.app_name
   model_uuid = var.model_uuid
-
-  charm {
-    name     = "temporal-k8s"
-    channel  = var.temporal.channel
-    revision = var.temporal.revision
-    base     = var.temporal.base
-  }
-
-  config = var.temporal.config
-  units  = var.temporal.units
+  channel    = local.channels.temporal
+  revision   = var.temporal.revision
+  base       = var.temporal.base
+  config     = var.temporal.config
+  resources  = var.temporal.resources
+  units      = var.temporal.units
 }
 
-resource "juju_application" "temporal_admin_k8s" {
-  name       = var.temporal_admin.app_name
+module "temporal_admin_k8s" {
+  source = "../modules/temporal-admin-k8s"
+
+  app_name   = var.temporal_admin.app_name
   model_uuid = var.model_uuid
-
-  charm {
-    name     = "temporal-admin-k8s"
-    channel  = var.temporal_admin.channel
-    revision = var.temporal_admin.revision
-    base     = var.temporal_admin.base
-  }
-
-  units = var.temporal_admin.units
+  channel    = local.channels.temporal_admin
+  revision   = var.temporal_admin.revision
+  base       = var.temporal_admin.base
+  config     = var.temporal_admin.config
+  resources  = var.temporal_admin.resources
+  units      = var.temporal_admin.units
 }
 
-resource "juju_application" "minio" {
-  name       = var.minio.app_name
-  model_uuid = var.model_uuid
+module "minio" {
+  source = "../modules/minio"
 
-  charm {
-    name     = "minio"
-    channel  = var.minio.channel
-    revision = var.minio.revision
-    base     = var.minio.base
-  }
-
+  app_name           = var.minio.app_name
+  model_uuid         = var.model_uuid
+  channel            = local.channels.minio
+  revision           = var.minio.revision
+  base               = var.minio.base
   config             = var.minio.config
+  resources          = var.minio.resources
   storage_directives = var.minio.storage_directives
   units              = var.minio.units
 }
@@ -112,8 +104,8 @@ resource "juju_integration" "airbyte_object_storage" {
     endpoint = module.airbyte.requires.object_storage
   }
   application {
-    name     = juju_application.minio.name
-    endpoint = "object-storage"
+    name     = module.minio.app_name
+    endpoint = module.minio.provides.object_storage
   }
 }
 
@@ -124,8 +116,8 @@ resource "juju_integration" "temporal_db" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.temporal_k8s.name
-    endpoint = "db"
+    name     = module.temporal_k8s.app_name
+    endpoint = module.temporal_k8s.requires.db
   }
   dynamic "application" {
     for_each = [local.database_endpoint]
@@ -141,8 +133,8 @@ resource "juju_integration" "temporal_visibility" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.temporal_k8s.name
-    endpoint = "visibility"
+    name     = module.temporal_k8s.app_name
+    endpoint = module.temporal_k8s.requires.visibility
   }
   dynamic "application" {
     for_each = [local.database_endpoint]
@@ -158,12 +150,12 @@ resource "juju_integration" "temporal_admin" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.temporal_k8s.name
-    endpoint = "admin"
+    name     = module.temporal_k8s.app_name
+    endpoint = module.temporal_k8s.requires.admin
   }
   application {
-    name     = juju_application.temporal_admin_k8s.name
-    endpoint = "admin"
+    name     = module.temporal_admin_k8s.app_name
+    endpoint = module.temporal_admin_k8s.provides.admin
   }
 }
 
@@ -171,11 +163,11 @@ resource "juju_integration" "temporal_host_info" {
   model_uuid = var.model_uuid
 
   application {
-    name     = juju_application.temporal_k8s.name
-    endpoint = "temporal-host-info"
+    name     = module.temporal_k8s.app_name
+    endpoint = module.temporal_k8s.provides.temporal_host_info
   }
   application {
-    name     = juju_application.temporal_admin_k8s.name
-    endpoint = "temporal-host-info"
+    name     = module.temporal_admin_k8s.app_name
+    endpoint = module.temporal_admin_k8s.provides.temporal_host_info
   }
 }

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -1,25 +1,47 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "model_uuid" {
-  description = "UUID of the model the product is deployed into."
-  value       = var.model_uuid
-}
-
 output "applications" {
   description = "Names of the deployed applications. postgresql-k8s is present only when deployed in-module."
   value = merge(
     {
       airbyte-k8s        = module.airbyte.app_name
-      temporal-k8s       = juju_application.temporal_k8s.name
-      temporal-admin-k8s = juju_application.temporal_admin_k8s.name
-      minio              = juju_application.minio.name
+      temporal-k8s       = module.temporal_k8s.app_name
+      temporal-admin-k8s = module.temporal_admin_k8s.app_name
+      minio              = module.minio.app_name
     },
-    local.deploy_database ? { postgresql-k8s = one(juju_application.postgresql_k8s[*].name) } : {},
+    local.deploy_database ? { postgresql-k8s = one(module.postgresql_k8s[*].app_name) } : {},
   )
 }
 
 output "database_offer_url" {
   description = "The external database offer URL in use, or null when PostgreSQL is deployed in-module."
   value       = local.deploy_database ? null : var.database_offer_url
+}
+
+output "metadata" {
+  description = "Metadata for the product deployment."
+  value = {
+    version     = "0.1.0"
+    deployed_at = plantimestamp()
+    updated_at  = plantimestamp()
+  }
+}
+
+output "models" {
+  description = "Map of the model key to the UUID and components deployed in it."
+  value = {
+    main = {
+      model_uuid = var.model_uuid
+      components = merge(
+        {
+          airbyte-k8s        = module.airbyte.app_name
+          temporal-k8s       = module.temporal_k8s.app_name
+          temporal-admin-k8s = module.temporal_admin_k8s.app_name
+          minio              = module.minio.app_name
+        },
+        local.deploy_database ? { postgresql-k8s = one(module.postgresql_k8s[*].app_name) } : {},
+      )
+    }
+  }
 }

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "model_uuid" {
+  description = "UUID of the model the product is deployed into."
+  value       = var.model_uuid
+}
+
+output "applications" {
+  description = "Names of the deployed applications. postgresql-k8s is present only when deployed in-module."
+  value = merge(
+    {
+      airbyte-k8s        = module.airbyte.app_name
+      temporal-k8s       = juju_application.temporal_k8s.name
+      temporal-admin-k8s = juju_application.temporal_admin_k8s.name
+      minio              = juju_application.minio.name
+    },
+    local.deploy_database ? { postgresql-k8s = one(juju_application.postgresql_k8s[*].name) } : {},
+  )
+}
+
+output "database_offer_url" {
+  description = "The external database offer URL in use, or null when PostgreSQL is deployed in-module."
+  value       = local.deploy_database ? null : var.database_offer_url
+}

--- a/terraform/product/terraform.tf
+++ b/terraform/product/terraform.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/terraform/product/tests/create_namespace/create-namespace.sh
+++ b/terraform/product/tests/create_namespace/create-namespace.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Runs the temporal-admin `cli` action to create a Temporal namespace, retrying until the action
+# reports "command succeeded" (or the namespace already exists), or until TIMEOUT seconds elapse.
+# Prints {"result": "<result>"} for the Terraform external data source.
+
+MODEL_UUID=$1
+APP_NAME=$2
+NAMESPACE=$3
+TIMEOUT=$4
+
+LOG="/tmp/create-namespace.$$.log"
+ERR="/tmp/create-namespace.$$.err"
+
+if [ -z "$MODEL_UUID" ] || [ -z "$APP_NAME" ] || [ -z "$NAMESPACE" ] || [ -z "$TIMEOUT" ]; then
+	echo '{"result": "bad_arguments"}'
+	exit 0
+fi
+
+deadline=$(($(date +%s) + TIMEOUT))
+result="unknown"
+while [ "$(date +%s)" -lt "$deadline" ]; do
+	out=$(juju run "$APP_NAME/0" cli args="operator namespace --namespace $NAMESPACE create" \
+		--model "$MODEL_UUID" --format=json --wait=2m 2>"$ERR")
+	echo "[$(date)] out=$out err=$(cat "$ERR")" >>"$LOG"
+
+	result=$(echo "$out" | jq -r ".[\"$APP_NAME/0\"].results.result // \"unknown\"" 2>>"$LOG")
+
+	# A fresh namespace yields "command succeeded"; a namespace that already exists (e.g. the
+	# data source re-running on apply) is equally acceptable.
+	if [ "$result" = "command succeeded" ] || grep -qi "already exists" "$ERR" <(echo "$out"); then
+		result="command succeeded"
+		break
+	fi
+
+	sleep 20
+done
+
+echo '{"result": "'"$result"'"}'

--- a/terraform/product/tests/create_namespace/main.tf
+++ b/terraform/product/tests/create_namespace/main.tf
@@ -1,0 +1,41 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    external = {
+      version = "> 2"
+      source  = "hashicorp/external"
+    }
+  }
+}
+
+variable "model_uuid" {
+  type = string
+}
+
+variable "app_name" {
+  description = "Name of the temporal-admin-k8s application whose `cli` action creates the namespace."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Temporal namespace to create."
+  type        = string
+  default     = "default"
+}
+
+variable "timeout" {
+  description = "Seconds to keep retrying the action while the admin charm becomes ready."
+  type        = number
+  default     = 600
+}
+
+# Runs the temporal-admin `cli` action to create the Temporal namespace. Terraform/juju_integration
+# is declarative and cannot run charm actions, so this mirrors the manual step the charm integration
+# tests perform (helpers.create_default_namespace) before Airbyte can reach active.
+# tflint-ignore: terraform_unused_declarations
+data "external" "create_namespace" {
+  program = ["bash", "${path.module}/create-namespace.sh", var.model_uuid, var.app_name, var.namespace, var.timeout]
+}

--- a/terraform/product/tests/main.tftest.hcl
+++ b/terraform/product/tests/main.tftest.hcl
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Defaults match CI (operator-workflows registers the K8s cloud as `tfk8s`). For local runs pass
+# globals via environment, e.g.:
+#   TF_VAR_k8s_cloud_name=microk8s TF_VAR_k8s_credential_name=microk8s \
+#   TF_VAR_k8s_workload_storage=microk8s-hostpath terraform test
+run "setup_tests" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "full_deploy" {
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+  }
+
+  assert {
+    condition     = output.applications["airbyte-k8s"] == "airbyte-k8s"
+    error_message = "airbyte-k8s application not present in the deployed applications"
+  }
+
+  assert {
+    condition     = output.applications["temporal-k8s"] == "temporal-k8s" && output.applications["minio"] == "minio"
+    error_message = "expected dependency applications were not deployed"
+  }
+}
+
+# Assert the full stack converges: airbyte-k8s only reaches active once its database and object
+# storage are related and its auth/dataplane credentials are resolved.
+run "wait_for_airbyte_active" {
+  module {
+    source = "./tests/wait_for_active"
+  }
+
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    app_name   = "airbyte-k8s"
+    timeout    = 1800
+  }
+
+  assert {
+    condition     = data.external.app_status.result.status == "active"
+    error_message = "airbyte-k8s did not reach active state"
+  }
+}

--- a/terraform/product/tests/main.tftest.hcl
+++ b/terraform/product/tests/main.tftest.hcl
@@ -27,8 +27,47 @@ run "full_deploy" {
   }
 }
 
+# Temporal must be active before its default namespace can be created.
+run "wait_for_temporal_active" {
+  module {
+    source = "./tests/wait_for_active"
+  }
+
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    app_name   = "temporal-k8s"
+    timeout    = 1200
+  }
+
+  assert {
+    condition     = data.external.app_status.result.status == "active"
+    error_message = "temporal-k8s did not reach active state"
+  }
+}
+
+# Create the Temporal `default` namespace via the temporal-admin `cli` action. Airbyte stays in
+# maintenance until this namespace exists; the product module is declarative and cannot run charm
+# actions, so the test performs this step (mirroring helpers.create_default_namespace).
+run "create_default_namespace" {
+  module {
+    source = "./tests/create_namespace"
+  }
+
+  variables {
+    model_uuid = run.setup_tests.model_uuid
+    app_name   = "temporal-admin-k8s"
+    namespace  = "default"
+    timeout    = 600
+  }
+
+  assert {
+    condition     = data.external.create_namespace.result.result == "command succeeded"
+    error_message = "failed to create the Temporal default namespace"
+  }
+}
+
 # Assert the full stack converges: airbyte-k8s only reaches active once its database and object
-# storage are related and its auth/dataplane credentials are resolved.
+# storage are related and the Temporal default namespace exists.
 run "wait_for_airbyte_active" {
   module {
     source = "./tests/wait_for_active"

--- a/terraform/product/tests/setup/main.tf
+++ b/terraform/product/tests/setup/main.tf
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    juju = {
+      version = "~> 2.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "k8s_workload_storage" {
+  description = "StorageClass for workloads in the K8s model. Empty uses the cloud default."
+  type        = string
+  default     = ""
+}
+
+variable "k8s_cloud_name" {
+  description = "Name of the Kubernetes cloud registered on the controller."
+  type        = string
+  default     = "tfk8s"
+}
+
+variable "k8s_credential_name" {
+  description = "Name of the credential for the Kubernetes cloud."
+  type        = string
+  default     = "tfk8s"
+}
+
+resource "juju_model" "k8s" {
+  name       = "tf-testing-airbyte-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  credential = var.k8s_credential_name
+
+  cloud {
+    name = var.k8s_cloud_name
+  }
+
+  config = var.k8s_workload_storage != "" ? { workload-storage = var.k8s_workload_storage } : {}
+}
+
+output "model_uuid" {
+  value = juju_model.k8s.uuid
+}

--- a/terraform/product/tests/wait_for_active/main.tf
+++ b/terraform/product/tests/wait_for_active/main.tf
@@ -1,0 +1,35 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    external = {
+      version = "> 2"
+      source  = "hashicorp/external"
+    }
+    juju = {
+      version = "~> 2.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "model_uuid" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "timeout" {
+  type = number
+}
+
+# tflint-ignore: terraform_unused_declarations
+data "external" "app_status" {
+  program = ["bash", "${path.module}/wait-for-active.sh", var.model_uuid, var.app_name, var.timeout]
+}

--- a/terraform/product/tests/wait_for_active/wait-for-active.sh
+++ b/terraform/product/tests/wait_for_active/wait-for-active.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Polls `juju status` until APP_NAME's application status is "active" (or "error", or until TIMEOUT
+# seconds elapse), then prints {"status": "<status>"} for the Terraform external data source.
+
+MODEL_UUID=$1
+APP_NAME=$2
+TIMEOUT=$3
+
+export APP_NAME
+LOG="/tmp/wait-for-active.$$.log"
+
+if [ -z "$MODEL_UUID" ] || [ -z "$APP_NAME" ] || [ -z "$TIMEOUT" ]; then
+	echo '{"status": "bad_arguments"}'
+	exit 0
+fi
+
+current_status() {
+	juju status "$APP_NAME" --model "$MODEL_UUID" --format=json 2>>"$LOG" |
+		jq -r '.applications[env.APP_NAME]["application-status"].current // "unknown"'
+}
+
+deadline=$(($(date +%s) + TIMEOUT))
+status="unknown"
+while [ "$(date +%s)" -lt "$deadline" ]; do
+	status=$(current_status)
+	echo "[$(date)] $APP_NAME: $status" >>"$LOG"
+	case "$status" in
+	active | error) break ;;
+	esac
+	sleep 20
+done
+
+echo '{"status": "'"$status"'"}'

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -33,7 +33,7 @@ variable "minio" {
     app_name           = optional(string, "minio")
     channel            = optional(string, "1.10/stable")
     revision           = optional(number)
-    base               = optional(string, "ubuntu@22.04")
+    base               = optional(string, "ubuntu@24.04")
     config             = optional(map(string), {})
     resources          = optional(map(string), {})
     storage_directives = optional(map(string), {})

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,11 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-variable "model_uuid" {
-  description = "UUID of the Kubernetes Juju model to deploy Airbyte and its dependencies into."
-  type        = string
-}
-
 variable "airbyte" {
   description = "Configuration for the airbyte-k8s charm."
   type = object({
@@ -32,6 +27,27 @@ variable "database_offer_url" {
   default     = ""
 }
 
+variable "minio" {
+  description = "Configuration for the minio charm (Airbyte object storage)."
+  type = object({
+    app_name           = optional(string, "minio")
+    channel            = optional(string, "1.10/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    config             = optional(map(string), {})
+    resources          = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "model_uuid" {
+  description = "UUID of the Kubernetes Juju model to deploy Airbyte and its dependencies into."
+  type        = string
+  nullable    = false
+}
+
 variable "postgresql" {
   description = "Configuration for the postgresql-k8s charm (shared database for Airbyte and Temporal; used when database_offer_url is empty)."
   type = object({
@@ -41,21 +57,38 @@ variable "postgresql" {
     base               = optional(string, "ubuntu@22.04")
     constraints        = optional(string)
     config             = optional(map(string), {})
+    resources          = optional(map(string), {})
     storage_directives = optional(map(string), {})
     units              = optional(number, 1)
   })
   default = {}
 }
 
+variable "risk" {
+  description = <<-EOT
+    Solution-wide risk level applied to every charm's channel, overriding the risk component
+    while preserving each charm's track (e.g. "14/stable" becomes "14/edge"). Leave null to use
+    each charm's own configured channel unchanged.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.risk == null || contains(["stable", "candidate", "beta", "edge"], var.risk)
+    error_message = "risk must be one of: stable, candidate, beta, edge."
+  }
+}
+
 variable "temporal" {
   description = "Configuration for the temporal-k8s charm (Airbyte's workflow engine)."
   type = object({
-    app_name = optional(string, "temporal-k8s")
-    channel  = optional(string, "1.23/stable")
-    revision = optional(number)
-    base     = optional(string, "ubuntu@24.04")
-    config   = optional(map(string), { num-history-shards = "4" })
-    units    = optional(number, 1)
+    app_name  = optional(string, "temporal-k8s")
+    channel   = optional(string, "1.23/stable")
+    revision  = optional(number)
+    base      = optional(string, "ubuntu@24.04")
+    config    = optional(map(string), { num-history-shards = "4" })
+    resources = optional(map(string), {})
+    units     = optional(number, 1)
   })
   default = {}
 }
@@ -63,25 +96,13 @@ variable "temporal" {
 variable "temporal_admin" {
   description = "Configuration for the temporal-admin-k8s charm (Temporal schema management)."
   type = object({
-    app_name = optional(string, "temporal-admin-k8s")
-    channel  = optional(string, "1.23/stable")
-    revision = optional(number)
-    base     = optional(string, "ubuntu@24.04")
-    units    = optional(number, 1)
-  })
-  default = {}
-}
-
-variable "minio" {
-  description = "Configuration for the minio charm (Airbyte object storage)."
-  type = object({
-    app_name           = optional(string, "minio")
-    channel            = optional(string, "1.10/stable")
-    revision           = optional(number)
-    base               = optional(string, "ubuntu@22.04")
-    config             = optional(map(string), {})
-    storage_directives = optional(map(string), {})
-    units              = optional(number, 1)
+    app_name  = optional(string, "temporal-admin-k8s")
+    channel   = optional(string, "1.23/stable")
+    revision  = optional(number)
+    base      = optional(string, "ubuntu@24.04")
+    config    = optional(map(string), {})
+    resources = optional(map(string), {})
+    units     = optional(number, 1)
   })
   default = {}
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,0 +1,87 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_uuid" {
+  description = "UUID of the Kubernetes Juju model to deploy Airbyte and its dependencies into."
+  type        = string
+}
+
+variable "airbyte" {
+  description = "Configuration for the airbyte-k8s charm."
+  type = object({
+    app_name    = optional(string, "airbyte-k8s")
+    channel     = optional(string, "latest/edge")
+    revision    = optional(number)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string)
+    config      = optional(map(string), {})
+    resources   = optional(map(string), {})
+    trust       = optional(bool, true)
+    units       = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "database_offer_url" {
+  description = <<-EOT
+    Offer URL for an external PostgreSQL `database` endpoint (e.g. a managed database on another
+    controller). Leave empty to deploy postgresql-k8s in-module and relate Airbyte and Temporal
+    to it; set it to relate them to the external database instead (postgresql-k8s is not deployed).
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "postgresql" {
+  description = "Configuration for the postgresql-k8s charm (shared database for Airbyte and Temporal; used when database_offer_url is empty)."
+  type = object({
+    app_name           = optional(string, "postgresql-k8s")
+    channel            = optional(string, "14/stable")
+    revision           = optional(number, 381)
+    base               = optional(string, "ubuntu@22.04")
+    constraints        = optional(string)
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "temporal" {
+  description = "Configuration for the temporal-k8s charm (Airbyte's workflow engine)."
+  type = object({
+    app_name = optional(string, "temporal-k8s")
+    channel  = optional(string, "1.23/stable")
+    revision = optional(number)
+    base     = optional(string, "ubuntu@24.04")
+    config   = optional(map(string), { num-history-shards = "4" })
+    units    = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "temporal_admin" {
+  description = "Configuration for the temporal-admin-k8s charm (Temporal schema management)."
+  type = object({
+    app_name = optional(string, "temporal-admin-k8s")
+    channel  = optional(string, "1.23/stable")
+    revision = optional(number)
+    base     = optional(string, "ubuntu@24.04")
+    units    = optional(number, 1)
+  })
+  default = {}
+}
+
+variable "minio" {
+  description = "Configuration for the minio charm (Airbyte object storage)."
+  type = object({
+    app_name           = optional(string, "minio")
+    channel            = optional(string, "1.10/stable")
+    revision           = optional(number)
+    base               = optional(string, "ubuntu@22.04")
+    config             = optional(map(string), {})
+    storage_directives = optional(map(string), {})
+    units              = optional(number, 1)
+  })
+  default = {}
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import Dict
@@ -28,6 +29,31 @@ def _collect_juju_logs_if_failed(request: FixtureRequest, juju: jubilant.Juju) -
     logger.info("Collecting Juju logs from model '%s'", juju.model)
     log = juju.debug_log(limit=1000)
     print(log, end="", file=sys.stderr)
+
+
+def _collect_k8s_diagnostics_if_failed(request: FixtureRequest, juju: jubilant.Juju) -> None:
+    """Print pod states and cluster events at teardown time when tests fail.
+
+    Args:
+        request: pytest request, used to detect test failures.
+        juju: Jubilant object for the model to collect diagnostics from.
+    """
+    if not request.session.testsfailed or not juju.model:
+        return
+
+    namespace = juju.model
+    commands = {
+        "pods": ["kubectl", "-n", namespace, "get", "pods", "-o", "wide"],
+        "pod details": ["kubectl", "-n", namespace, "describe", "pods"],
+        "events": ["kubectl", "-n", namespace, "get", "events", "--sort-by=.lastTimestamp"],
+    }
+    for label, command in commands.items():
+        logger.info("Collecting K8s %s from namespace '%s'", label, namespace)
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, check=False, timeout=120)  # nosec B603
+            print(f"\n===== kubectl {label} ({namespace}) =====\n{result.stdout}{result.stderr}", file=sys.stderr)
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning("Could not collect K8s %s: %s", label, exc)
 
 
 @pytest.fixture(scope="session")
@@ -104,8 +130,10 @@ def k8s_juju(request: FixtureRequest) -> jubilant.Juju:
             yield juju
         finally:
             _collect_juju_logs_if_failed(request, juju)
+            _collect_k8s_diagnostics_if_failed(request, juju)
     else:
         with jubilant.temp_model() as juju:
             juju.wait_timeout = 30 * 60
             yield juju
             _collect_juju_logs_if_failed(request, juju)
+            _collect_k8s_diagnostics_if_failed(request, juju)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -37,8 +37,6 @@ TEMPORAL_BASE = "ubuntu@24.04"
 INTERNAL_API_PORT = 8001
 TEMPORAL_PORT = 7233
 
-WORKLOAD_LAUNCHER_CONTAINER = "airbyte-workload-launcher"
-
 GET_HEADERS = {"accept": "application/json"}
 POST_HEADERS = {"accept": "application/json", "content-type": "application/json"}
 
@@ -550,31 +548,12 @@ def cancel_airbyte_job(api_url, job_id):
     return response.json().get("status")
 
 
-def restart_workload_launcher(juju: jubilant.Juju) -> None:
-    """Restart the workload launcher so it re-initialises its dataplane identity.
-
-    Args:
-        juju: Jubilant object.
-    """
-    logger.info("restarting %s to force dataplane re-registration", WORKLOAD_LAUNCHER_CONTAINER)
-    juju.ssh(
-        f"{APP_NAME_AIRBYTE_SERVER}/0",
-        "pebble",
-        "restart",
-        WORKLOAD_LAUNCHER_CONTAINER,
-        container=WORKLOAD_LAUNCHER_CONTAINER,
-    )
-    wait_for_all_active(juju, [APP_NAME_AIRBYTE_SERVER], timeout=5 * 60)
-
-
 def run_test_sync_job(juju: jubilant.Juju) -> None:
     """Run a test Airbyte connection end to end and assert it succeeds.
 
     Args:
         juju: Jubilant object.
     """
-    restart_workload_launcher(juju)
-
     api_url = get_unit_url(juju, APP_NAME_AIRBYTE_SERVER, 0, INTERNAL_API_PORT)
     logger.info("curling app address: %s", api_url)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -37,6 +37,8 @@ TEMPORAL_BASE = "ubuntu@24.04"
 INTERNAL_API_PORT = 8001
 TEMPORAL_PORT = 7233
 
+WORKLOAD_LAUNCHER_CONTAINER = "airbyte-workload-launcher"
+
 GET_HEADERS = {"accept": "application/json"}
 POST_HEADERS = {"accept": "application/json", "content-type": "application/json"}
 
@@ -548,12 +550,31 @@ def cancel_airbyte_job(api_url, job_id):
     return response.json().get("status")
 
 
+def restart_workload_launcher(juju: jubilant.Juju) -> None:
+    """Restart the workload launcher so it re-initialises its dataplane identity.
+
+    Args:
+        juju: Jubilant object.
+    """
+    logger.info("restarting %s to force dataplane re-registration", WORKLOAD_LAUNCHER_CONTAINER)
+    juju.ssh(
+        f"{APP_NAME_AIRBYTE_SERVER}/0",
+        "pebble",
+        "restart",
+        WORKLOAD_LAUNCHER_CONTAINER,
+        container=WORKLOAD_LAUNCHER_CONTAINER,
+    )
+    wait_for_all_active(juju, [APP_NAME_AIRBYTE_SERVER], timeout=5 * 60)
+
+
 def run_test_sync_job(juju: jubilant.Juju) -> None:
     """Run a test Airbyte connection end to end and assert it succeeds.
 
     Args:
         juju: Jubilant object.
     """
+    restart_workload_launcher(juju)
+
     api_url = get_unit_url(juju, APP_NAME_AIRBYTE_SERVER, 0, INTERNAL_API_PORT)
     logger.info("curling app address: %s", api_url)
 


### PR DESCRIPTION
This PR adds reference TF modules for deploying `airbyte-k8s` via the Juju provider, mirroring the [`canonical/datahub-k8s-operator`](https://github.com/canonical/datahub-k8s-operator/tree/main/terraform) layout.

- **`charm/`** — base module for the `airbyte-k8s` application: all charm config options, `provides`/`requires` endpoint outputs, and `trust` enabled (the charm reads/patches its K8s auth secret).
- **`product/`** — full-stack deployment of `airbyte-k8s` with `postgresql-k8s`, `temporal-k8s`, `temporal-admin-k8s` and `minio`, wiring the integrations from the integration-test stack. A `database_offer_url` toggle swaps the in-module PostgreSQL for an external database offer.
- **`tests/`** for both modules: `setup/` fixtures that create the Juju model, a `wait_for_active` helper, and `.tftest.hcl` assertions.