### PR TITLE
fix[CSS-22886]: surface bootloader failures and fix post-upgrade sync dispatch

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,7 @@ from structured_config import CharmConfig, StorageType
 
 logger = logging.getLogger(__name__)
 
-BOOTLOADER_FAILED_MESSAGE = "airbyte-bootloader failed; check the airbyte-bootloader container logs"
+BOOTLOADER_WAITING_MESSAGE = "waiting for airbyte-bootloader to complete"
 
 
 def get_pebble_layer(application_name, context):
@@ -287,7 +287,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             return
 
         if self._bootloader_failed():
-            self.unit.status = BlockedStatus(BOOTLOADER_FAILED_MESSAGE)
+            self.unit.status = WaitingStatus(BOOTLOADER_WAITING_MESSAGE)
             return
 
         self.unit.set_workload_version(f"v{AIRBYTE_VERSION}")
@@ -552,7 +552,7 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             container.replan()
 
         if self._bootloader_failed():
-            self.unit.status = BlockedStatus(BOOTLOADER_FAILED_MESSAGE)
+            self.unit.status = WaitingStatus(BOOTLOADER_WAITING_MESSAGE)
             return
 
         if not auth_env:

--- a/src/charm.py
+++ b/src/charm.py
@@ -44,6 +44,8 @@ from structured_config import CharmConfig, StorageType
 
 logger = logging.getLogger(__name__)
 
+BOOTLOADER_FAILED_MESSAGE = "airbyte-bootloader failed; check the airbyte-bootloader container logs"
+
 
 def get_pebble_layer(application_name, context):
     """Create pebble layer based on application.
@@ -284,6 +286,10 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             self.reconcile()
             return
 
+        if self._bootloader_failed():
+            self.unit.status = BlockedStatus(BOOTLOADER_FAILED_MESSAGE)
+            return
+
         self.unit.set_workload_version(f"v{AIRBYTE_VERSION}")
         self.unit.status = ActiveStatus()
         if self.unit.is_leader():
@@ -453,6 +459,17 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             "AB_JWT_SIGNATURE_SECRET": jwt_signature_secret,
         }
 
+    def _bootloader_failed(self):
+        """Return True if the airbyte-bootloader is crash-looping instead of having completed."""
+        container = self.unit.get_container("airbyte-bootloader")
+        if not container.can_connect():
+            return False
+        service = container.get_services("airbyte-bootloader").get("airbyte-bootloader")
+        if service is None:
+            return False
+        healthy = (ops.pebble.ServiceStatus.ACTIVE, ops.pebble.ServiceStatus.INACTIVE)
+        return service.current not in healthy
+
     def reconcile(self):  # noqa: C901
         """Reconcile the charm to its desired state.
 
@@ -533,6 +550,10 @@ class AirbyteK8SOperatorCharm(TypedCharmBase[CharmConfig]):
             pebble_layer = get_pebble_layer(container_name, env)
             container.add_layer(container_name, pebble_layer, combine=True)
             container.replan()
+
+        if self._bootloader_failed():
+            self.unit.status = BlockedStatus(BOOTLOADER_FAILED_MESSAGE)
+            return
 
         if not auth_env:
             self.unit.status = WaitingStatus("waiting for airbyte-auth-secrets")

--- a/src/literals.py
+++ b/src/literals.py
@@ -87,6 +87,9 @@ BASE_ENV = {
     "PUB_SUB_ENABLED": "false",
     "PUB_SUB_TOPIC_NAME": "",
     "DATA_PLANE_ID": "local",
+    # Name of the dataplane group the launcher serves; must match the group Airbyte routes work to
+    # (the "AUTO" group from v1), else the launcher serves an orphan group and syncs never run.
+    "DEFAULT_DATAPLANE_GROUP_NAME": "AUTO",
     "LOCAL_ROOT": "/tmp/airbyte_local",  # nosec
     "RUN_DATABASE_MIGRATION_ON_STARTUP": "true",
     "API_AUTHORIZATION_ENABLED": "false",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -548,11 +548,14 @@ def cancel_airbyte_job(api_url, job_id):
     return response.json().get("status")
 
 
-def run_test_sync_job(juju: jubilant.Juju) -> None:
-    """Run a test Airbyte connection end to end and assert it succeeds.
+def create_test_connection(juju: jubilant.Juju) -> str:
+    """Create a source, destination and connection, returning the connection ID.
 
     Args:
         juju: Jubilant object.
+
+    Returns:
+        The created Airbyte connection ID.
     """
     api_url = get_unit_url(juju, APP_NAME_AIRBYTE_SERVER, 0, INTERNAL_API_PORT)
     logger.info("curling app address: %s", api_url)
@@ -564,7 +567,17 @@ def run_test_sync_job(juju: jubilant.Juju) -> None:
     model_name = model_short_name(juju.model or "")
     source_id = create_airbyte_source(api_url, workspace_id)
     destination_id = create_airbyte_destination(api_url, model_name, workspace_id, db_password)
-    connection_id = create_airbyte_connection(api_url, source_id, destination_id)
+    return create_airbyte_connection(api_url, source_id, destination_id)
+
+
+def sync_connection(juju: jubilant.Juju, connection_id: str) -> None:
+    """Trigger a sync on an existing connection and assert it succeeds.
+
+    Args:
+        juju: Jubilant object.
+        connection_id: the Airbyte connection to sync.
+    """
+    api_url = get_unit_url(juju, APP_NAME_AIRBYTE_SERVER, 0, INTERNAL_API_PORT)
 
     job_successful = False
     for i in range(4):
@@ -592,3 +605,13 @@ def run_test_sync_job(juju: jubilant.Juju) -> None:
         cancel_airbyte_job(api_url, job_id)
 
     assert job_successful
+
+
+def run_test_sync_job(juju: jubilant.Juju) -> None:
+    """Create a connection and run it end to end, asserting the sync succeeds.
+
+    Args:
+        juju: Jubilant object.
+    """
+    connection_id = create_test_connection(juju)
+    sync_connection(juju, connection_id)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 BASELINE_CHANNEL = "latest/edge"
 
 
-PREVIOUS_MAJOR_STABLE_CHANNEL = "1/stable"
+PREVIOUS_MAJOR_CHANNEL = "1/edge"
 
 
 def _published_channels(charm_name: str) -> set[str]:
@@ -83,27 +83,33 @@ def test_refresh_from_published(baseline_stack: jubilant.Juju, charm: Path, rock
 
 
 def test_major_upgrade(charm: Path, rock_resources: dict):
-    """The previous major's stable charm refreshes to the local build and keeps serving.
+    """The previous major's charm refreshes to the local build and keeps serving.
 
     Args:
         charm: Path to the locally built charm package.
         rock_resources: Resource-name to local image map for the local build.
     """
     published = _published_channels(helpers.APP_NAME_AIRBYTE_SERVER)
-    if PREVIOUS_MAJOR_STABLE_CHANNEL not in published:
+    if PREVIOUS_MAJOR_CHANNEL not in published:
         pytest.skip(
-            f"channel '{PREVIOUS_MAJOR_STABLE_CHANNEL}' is not published (or Charmhub is "
+            f"channel '{PREVIOUS_MAJOR_CHANNEL}' is not published (or Charmhub is "
             "unreachable) - major upgrade not testable yet"
         )
 
     with jubilant.temp_model() as juju:
         juju.wait_timeout = 30 * 60
 
-        logger.info("Deploying baseline full stack from '%s'", PREVIOUS_MAJOR_STABLE_CHANNEL)
-        helpers.deploy_full_stack(juju, channel=PREVIOUS_MAJOR_STABLE_CHANNEL)
+        logger.info("Deploying baseline full stack from '%s'", PREVIOUS_MAJOR_CHANNEL)
+        helpers.deploy_full_stack(juju, channel=PREVIOUS_MAJOR_CHANNEL)
 
         logger.info("Verifying the previous major serves before the refresh")
         helpers.assert_serving(juju)
+
+        # Create a connection under the previous major so the upgrade must carry an existing
+        # connection (bound to the legacy default dataplane group) through to a working sync.
+        logger.info("Seeding and syncing a connection under the previous major")
+        connection_id = helpers.create_test_connection(juju)
+        helpers.sync_connection(juju, connection_id)
 
         logger.info("Refreshing '%s' to the local charm + local rock", helpers.APP_NAME_AIRBYTE_SERVER)
         juju.refresh(helpers.APP_NAME_AIRBYTE_SERVER, path=charm, resources=rock_resources)
@@ -112,7 +118,9 @@ def test_major_upgrade(charm: Path, rock_resources: dict):
         juju.wait(lambda status: jubilant.all_agents_idle(status, helpers.APP_NAME_AIRBYTE_SERVER), timeout=10 * 60)
         helpers.wait_for_all_active(juju, [helpers.APP_NAME_AIRBYTE_SERVER], timeout=20 * 60)
 
-        logger.info("Verifying the refreshed charm still serves and syncs after the major upgrade")
+        logger.info("Verifying the refreshed charm still serves after the major upgrade")
         helpers.wait_until_healthy(juju)
         helpers.assert_serving(juju)
-        helpers.run_test_sync_job(juju)
+
+        logger.info("Re-syncing the pre-existing connection after the major upgrade")
+        helpers.sync_connection(juju, connection_id)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,9 +18,9 @@ from unittest.mock import MagicMock, patch
 from kubernetes.client.exceptions import ApiException
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
-from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer
+from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer, ServiceStatus
 
-from charm import AirbyteK8SOperatorCharm
+from charm import BOOTLOADER_FAILED_MESSAGE, AirbyteK8SOperatorCharm
 from src.literals import (
     BASE_ENV,
     CONTAINER_HEALTH_CHECK_MAP,
@@ -174,6 +174,22 @@ class TestCharm(TestCase):
         mid = with_checks(mid, CheckStatus.DOWN)
         out = self.ctx.run(self.ctx.on.update_status(), mid)
         self.assertEqual(out.unit_status, MaintenanceStatus("Status check: 'airbyte-workload-api-server' DOWN"))
+
+    def test_update_status_blocked_when_bootloader_failed(self):
+        """A crash-looping bootloader blocks the unit instead of reporting active."""
+        state = make_state(db=True, minio=True)
+        mid = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
+        mid = with_checks(mid, CheckStatus.UP)
+
+        containers = set()
+        for container in mid.containers:
+            if container.name == "airbyte-bootloader":
+                container = dataclasses.replace(container, service_statuses={"airbyte-bootloader": ServiceStatus.ERROR})
+            containers.add(container)
+        mid = dataclasses.replace(mid, containers=containers)
+
+        out = self.ctx.run(self.ctx.on.update_status(), mid)
+        self.assertEqual(out.unit_status, BlockedStatus(BOOTLOADER_FAILED_MESSAGE))
 
     def test_incomplete_pebble_plan(self):
         """The charm re-applies the pebble plan if incomplete."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,7 +20,7 @@ from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckLevel, CheckStartup, CheckStatus, Layer, ServiceStatus
 
-from charm import BOOTLOADER_FAILED_MESSAGE, AirbyteK8SOperatorCharm
+from charm import BOOTLOADER_WAITING_MESSAGE, AirbyteK8SOperatorCharm
 from src.literals import (
     BASE_ENV,
     CONTAINER_HEALTH_CHECK_MAP,
@@ -175,8 +175,8 @@ class TestCharm(TestCase):
         out = self.ctx.run(self.ctx.on.update_status(), mid)
         self.assertEqual(out.unit_status, MaintenanceStatus("Status check: 'airbyte-workload-api-server' DOWN"))
 
-    def test_update_status_blocked_when_bootloader_failed(self):
-        """A crash-looping bootloader blocks the unit instead of reporting active."""
+    def test_update_status_waiting_when_bootloader_failed(self):
+        """A crash-looping bootloader leaves the unit waiting instead of reporting active."""
         state = make_state(db=True, minio=True)
         mid = self.ctx.run(self.ctx.on.pebble_ready(get_container(state, "airbyte-server")), state)
         mid = with_checks(mid, CheckStatus.UP)
@@ -189,7 +189,7 @@ class TestCharm(TestCase):
         mid = dataclasses.replace(mid, containers=containers)
 
         out = self.ctx.run(self.ctx.on.update_status(), mid)
-        self.assertEqual(out.unit_status, BlockedStatus(BOOTLOADER_FAILED_MESSAGE))
+        self.assertEqual(out.unit_status, WaitingStatus(BOOTLOADER_WAITING_MESSAGE))
 
     def test_incomplete_pebble_plan(self):
         """The charm re-applies the pebble plan if incomplete."""


### PR DESCRIPTION
Follow-up fixes found while validating the Airbyte v2.0.0 upgrade on staging. Fixes two issues and hardens the test that missed them.

## Changes
- Gate on bootloader failure: the unit now blocks when `airbyte-bootloader` crash-loops (e.g. a failed DB migration) instead of reporting `active`.
- Fix post-upgrade sync dispatch: set `DEFAULT_DATAPLANE_GROUP_NAME=AUTO` so the launcher serves the dataplane group Airbyte routes work to. The bootloader looks its default group up [by name](https://github.com/airbytehq/airbyte-platform/blob/v2.0.0/airbyte-bootloader/src/main/kotlin/io/airbyte/bootloader/DataplaneInitializer.kt), and the env [defaults to empty](https://github.com/airbytehq/airbyte-platform/blob/v2.0.0/airbyte-bootloader/src/main/resources/application.yml), so without it a v1 -> v2 upgrade leaves pre-existing connections on the migrated `AUTO` group while the launcher polls an [orphan group](https://github.com/airbytehq/airbyte-platform/blob/v2.0.0/airbyte-bootloader/src/main/kotlin/io/airbyte/bootloader/Bootloader.kt#L89) and syncs hang.
- Upgrade test: `test_major_upgrade` now seeds a connection under the previous major and re-syncs it after upgrade.